### PR TITLE
Directly import GetSet generator

### DIFF
--- a/cellengine/resources/compensation.py
+++ b/cellengine/resources/compensation.py
@@ -3,6 +3,7 @@ import pandas
 import numpy
 from cellengine.client import session
 from cellengine.utils import helpers
+from cellengine.utils.helpers import GetSet
 
 
 @attr.s(repr=False, slots=True)
@@ -18,13 +19,13 @@ class Compensation(object):
 
     _dataframe = attr.ib(default=None, repr=False)
 
-    _id = helpers.GetSet("_id", read_only=True)
+    _id = GetSet("_id", read_only=True)
 
-    name = helpers.GetSet("name")
+    name = GetSet("name")
 
-    experiment_id = helpers.GetSet("experimentId")
+    experiment_id = GetSet("experimentId")
 
-    channels = helpers.GetSet("channels")
+    channels = GetSet("channels")
 
     @property
     def N(self):

--- a/cellengine/resources/experiment.py
+++ b/cellengine/resources/experiment.py
@@ -3,6 +3,7 @@ from typing import Optional
 from custom_inherit import doc_inherit
 
 from cellengine.utils import helpers
+from cellengine.utils.helpers import GetSet, CommentList
 from cellengine.utils.loader import Loader
 from cellengine.utils.complex_population_creator import create_complex_population
 from cellengine.resources.population import Population
@@ -29,9 +30,9 @@ class Experiment(object):
 
     _properties = attr.ib()
 
-    _id = helpers.GetSet("_id", read_only=True)
+    _id = GetSet("_id", read_only=True)
 
-    name = helpers.GetSet("name")
+    name = GetSet("name")
 
     def __repr__(self):
         return "Experiment(_id='{0}', name='{1}')".format(self._id, self.name)
@@ -45,8 +46,8 @@ class Experiment(object):
     @property
     def comments(self):
         comments = self._properties["comments"]
-        if type(comments) is not helpers.CommentList:
-            self._properties["comments"] = helpers.CommentList(comments)
+        if type(comments) is not CommentList:
+            self._properties["comments"] = CommentList(comments)
         return comments
 
     @comments.setter
@@ -87,31 +88,31 @@ class Experiment(object):
         else:
             pass
 
-    public = helpers.GetSet("public")
+    public = GetSet("public")
 
-    uploader = helpers.GetSet("uploader")
+    uploader = GetSet("uploader")
 
-    primary_researcher = helpers.GetSet("primaryResearcher")
+    primary_researcher = GetSet("primaryResearcher")
 
-    active_compensation = helpers.GetSet("activeCompensation")
+    active_compensation = GetSet("activeCompensation")
 
-    locked = helpers.GetSet("locked")
+    locked = GetSet("locked")
 
-    clone_source_experiment = helpers.GetSet("cloneSourceExperiment")
+    clone_source_experiment = GetSet("cloneSourceExperiment")
 
-    revision_source_experiment = helpers.GetSet("revisionSourceExperiment")
+    revision_source_experiment = GetSet("revisionSourceExperiment")
 
-    revisions = helpers.GetSet("revisions")
+    revisions = GetSet("revisions")
 
-    per_file_compensations_enabled = helpers.GetSet("perFileCompensationsEnabled")
+    per_file_compensations_enabled = GetSet("perFileCompensationsEnabled")
 
-    tags = helpers.GetSet("tags")
+    tags = GetSet("tags")
 
-    annotation_name_order = helpers.GetSet("annotationNameOrder")
+    annotation_name_order = GetSet("annotationNameOrder")
 
-    annotation_table_sort_columns = helpers.GetSet("annotationTableSortColumns")
+    annotation_table_sort_columns = GetSet("annotationTableSortColumns")
 
-    permissions = helpers.GetSet("permissions")
+    permissions = GetSet("permissions")
 
     @property
     def created(self):

--- a/cellengine/resources/fcsfile.py
+++ b/cellengine/resources/fcsfile.py
@@ -2,6 +2,7 @@ import attr
 import pandas
 import fcsparser
 from cellengine.utils import helpers
+from cellengine.utils.helpers import GetSet
 
 
 @attr.s(repr=False, slots=True)
@@ -15,27 +16,27 @@ class FcsFile(object):
 
     _events = attr.ib(default=None)
 
-    name = helpers.GetSet("filename")
+    name = GetSet("filename")
 
-    _id = helpers.GetSet("_id", read_only=True)
+    _id = GetSet("_id", read_only=True)
 
-    experiment_id = helpers.GetSet("experimentId", read_only=True)
+    experiment_id = GetSet("experimentId", read_only=True)
 
-    panel_name = helpers.GetSet("panelName")
+    panel_name = GetSet("panelName")
 
-    event_count = helpers.GetSet("eventCount")
+    event_count = GetSet("eventCount")
 
-    has_file_internal_comp = helpers.GetSet("hasFileInternalComp")
+    has_file_internal_comp = GetSet("hasFileInternalComp")
 
-    size = helpers.GetSet("size")
+    size = GetSet("size")
 
-    md5 = helpers.GetSet("md5")
+    md5 = GetSet("md5")
 
-    filename = helpers.GetSet("filename")
+    filename = GetSet("filename")
 
-    panel = helpers.GetSet("panel")
+    panel = GetSet("panel")
 
-    compensation = helpers.GetSet("compensation")
+    compensation = GetSet("compensation")
 
     @property
     def annotations(self):

--- a/cellengine/resources/gate.py
+++ b/cellengine/resources/gate.py
@@ -2,6 +2,7 @@ from typing import Dict, List
 import attr
 import numpy
 from cellengine.utils import helpers
+from cellengine.utils.helpers import GetSet, convert_dict
 from cellengine.utils.helpers import convert_dict
 from cellengine.resources import Gates
 from custom_inherit import doc_inherit
@@ -104,27 +105,27 @@ class Gate(ABC):
         self._posted = True
         self._properties = res._properties
 
-    _id = helpers.GetSet("_id", read_only=True)
+    _id = GetSet("_id", read_only=True)
 
-    name = helpers.GetSet("name")
+    name = GetSet("name")
 
-    type = helpers.GetSet("type", read_only=True)
+    type = GetSet("type", read_only=True)
 
-    experiment_id = helpers.GetSet("experimentId", read_only=True)
+    experiment_id = GetSet("experimentId", read_only=True)
 
-    gid = helpers.GetSet("gid")
+    gid = GetSet("gid")
 
-    x_channel = helpers.GetSet("xChannel")
+    x_channel = GetSet("xChannel")
 
-    y_channel = helpers.GetSet("yChannel")
+    y_channel = GetSet("yChannel")
 
-    tailored_per_file = helpers.GetSet("tailoredPerFile")
+    tailored_per_file = GetSet("tailoredPerFile")
 
-    fcs_file_id = helpers.GetSet("fcsFileId")
+    fcs_file_id = GetSet("fcsFileId")
 
-    parent_population_id = helpers.GetSet("parentPopulationId")
+    parent_population_id = GetSet("parentPopulationId")
 
-    names = helpers.GetSet("names")
+    names = GetSet("names")
 
     # TODO: create_population()
 

--- a/cellengine/resources/population.py
+++ b/cellengine/resources/population.py
@@ -1,6 +1,7 @@
 cellengine = __import__(__name__.split(".")[0])
 import attr
 from cellengine.utils import helpers
+from cellengine.utils.helpers import GetSet
 
 
 @attr.s(repr=False, slots=True)
@@ -17,19 +18,19 @@ class Population(object):
 
     _properties = attr.ib()
 
-    _id = helpers.GetSet("_id", read_only=True)
+    _id = GetSet("_id", read_only=True)
 
-    name = helpers.GetSet("name")
+    name = GetSet("name")
 
-    experiment_id = helpers.GetSet("experimentId", read_only=True)
+    experiment_id = GetSet("experimentId", read_only=True)
 
-    gates = helpers.GetSet("gates")
+    gates = GetSet("gates")
 
-    terminal_gate_gid = helpers.GetSet("terminalGateId")
+    terminal_gate_gid = GetSet("terminalGateId")
 
-    parent_id = helpers.GetSet("parentId")
+    parent_id = GetSet("parentId")
 
-    unique_name = helpers.GetSet("uniqueName", read_only=True)
+    unique_name = GetSet("uniqueName", read_only=True)
 
     def update(self):
         """Save any changed data to CellEngine."""


### PR DESCRIPTION
Importing the GetSet generator once from `helpers`, rather than every time it's
used, gets us a slight performance increase when creating resources