### PR TITLE
Add update method to all resources

### DIFF
--- a/cellengine/resources/attachments.py
+++ b/cellengine/resources/attachments.py
@@ -1,0 +1,34 @@
+import attr
+
+@attr.s(repr=False, slots=True)
+class Attachment(object):
+    """A class representing a CellEngine attachment.
+    Attachments are non-data files that are stored in an experiment.
+    """
+
+    def __repr__(self):
+        return "Attachment(_id='{0}', name='{1}')".format(self._id, self.name)
+
+    _properties = attr.ib(default={}, repr=False)
+
+    crc32c = GetSet("crc32c", read_only=True)
+
+    experiment_id = GetSet("experimentId", read_only=True)
+
+    filename = GetSet("filename")
+
+    md5 = GetSet("md5", read_only=True)
+
+    size = GetSet("size", read_only=True)
+
+    # API Methods
+
+    # upload
+
+    # list
+
+    # delete
+
+    # update
+
+    # download

--- a/cellengine/resources/compensation.py
+++ b/cellengine/resources/compensation.py
@@ -48,12 +48,12 @@ class Compensation(object):
     def dataframe_as_html(self):
         return self.dataframe._repr_html_()
 
-    def apply(self, file, inplace=True):
+    def apply(self, file, inplace: bool = True):
         """
         Compensates the file's data.
 
-        :type parser: :class:`cellengine.FcsFile`
-        :param parser: The FCS file to compensate.
+        :type file: :class:`cellengine.FcsFile`
+        :param file: The FCS file to compensate.
 
         :type inplace: bool
         :param inplace: Compensate the file's data in-place.
@@ -75,3 +75,9 @@ class Compensation(object):
             file._events = data
         else:
             return data
+
+    # API methods
+    def update(self):
+        res = helpers.base_update("experiments/{0}/compensations/{1}".format(self.experiment_id, self._id), body = self._properties)
+        self._properties.update(res)
+

--- a/cellengine/resources/experiment.py
+++ b/cellengine/resources/experiment.py
@@ -1,5 +1,5 @@
 import attr
-from typing import Optional
+from typing import Optional, Dict
 from custom_inherit import doc_inherit
 
 from cellengine.utils import helpers
@@ -51,7 +51,7 @@ class Experiment(object):
         return comments
 
     @comments.setter
-    def comments(self, comments):
+    def comments(self, comments: Dict):
         """Sets comments for experiment.
 
         Defaults to overwrite; append new comments with
@@ -77,7 +77,7 @@ class Experiment(object):
             return helpers.timestamp_to_datetime(self._properties.get("deleted"))
 
     @property
-    def deleted(self, confirm=True):
+    def delete(self, confirm=True):
         """Marks the experiment as deleted.
 
         Deleted experiments are permanently deleted after approximately
@@ -145,7 +145,8 @@ class Experiment(object):
 
     # API methods
     def update(self):
-        res = base_update("experiments/{0}", body = self._properties, classname = 'Experiment')
+        res = helpers.base_update("experiments/{0}".format(self._id), body = self._properties)
+        self._properties.update(res)
 
     # Gate Methods:
 

--- a/cellengine/resources/fcsfile.py
+++ b/cellengine/resources/fcsfile.py
@@ -10,7 +10,7 @@ class FcsFile(object):
     """A class representing a CellEngine FCS file."""
 
     def __repr__(self):
-        return "FcsFile(_id='{0}', name='{1}')".format(self._id, self.name)
+        return "FcsFile(_id={0}, name='{1}')".format(self._id, self.name)
 
     _properties = attr.ib(default={}, repr=False)
 
@@ -73,3 +73,13 @@ class FcsFile(object):
     @events.setter
     def events(self, val):
         self.__dict__["_events"] = val
+
+    # API methods
+    def update(self):
+        """Save any changed data to CellEngine."""
+        res = helpers.base_update(
+            "experiments/{0}/compensations/{1}".format(self.experiment_id, self._id),
+            body=self._properties,
+        )
+        self._properties.update(res)
+

--- a/cellengine/resources/gate.py
+++ b/cellengine/resources/gate.py
@@ -191,6 +191,11 @@ class Gate(ABC):
 
         helpers.base_delete(url)
 
+    # API methods
+    def update(self):
+        res = helpers.base_update("experiments/{0}/gates/{1}".format(self.experiment_id, self._id), body = self._properties)
+        self._properties.update(res)
+
 
 class RectangleGate(Gate):
     """Basic concrete class for polygon gates"""

--- a/cellengine/resources/population.py
+++ b/cellengine/resources/population.py
@@ -32,14 +32,14 @@ class Population(object):
 
     unique_name = GetSet("uniqueName", read_only=True)
 
+    # API methods
     def update(self):
         """Save any changed data to CellEngine."""
-        return helpers.base_update(
+        res = helpers.base_update(
             "experiments/{0}/populations/{1}".format(self.experiment_id, self._id),
             body=self._properties,
-            classname=Population,
         )
-
+        self._properties.update(res)
 
     def delete(self):
         return helpers.base_delete(

--- a/cellengine/utils/helpers.py
+++ b/cellengine/utils/helpers.py
@@ -201,13 +201,10 @@ def parse_population_from_gate(content: Dict) -> str:
             return content
 
 
-def base_update(url, body: Dict = None, classname: Union[str, 'APIObject'] = None, **kwargs) -> str:
+def base_update(url, body: Dict = None, **kwargs) -> str:
     res = session.patch(url, json=body, **kwargs)
     res.raise_for_status()
-    if classname:
-        return make_class(classname, content=res.json())
-    else:
-        return res.json()
+    return res.json()
 
 
 def base_delete(url: str) -> str:

--- a/tests/unit/resources/test_compensation.py
+++ b/tests/unit/resources/test_compensation.py
@@ -1,4 +1,5 @@
 import os
+import json
 import pytest
 import responses
 import pandas
@@ -19,18 +20,42 @@ def compensation(experiment, compensations):
         return experiment.compensations[0]
 
 
+def properties_tester(comp):
+    assert type(comp._properties) is dict
+    assert type(comp) is cellengine.Compensation
+    assert hasattr(comp, "_id")
+    assert hasattr(comp, "name")
+    assert hasattr(comp, "experiment_id")
+    assert hasattr(comp, "channels")
+    assert hasattr(comp, "N")
+    assert comp.N == len(comp.dataframe)
+    assert hasattr(comp, "dataframe")
+    assert type(comp.dataframe) is pandas.core.frame.DataFrame
+    assert all(comp.dataframe.index == comp.channels)
+    assert hasattr(comp, "apply")
+    assert hasattr(comp, "dataframe_as_html")
+
+def test_compensation_properties(compensation):
+    properties_tester(compensation)
+
 @responses.activate
-def test_all_experiment_properties(compensation):
-    assert type(compensation._properties) is dict
-    assert type(compensation) is cellengine.Compensation
-    assert hasattr(compensation, "_id")
-    assert hasattr(compensation, "name")
-    assert hasattr(compensation, "experiment_id")
-    assert hasattr(compensation, "channels")
-    assert hasattr(compensation, "N")
-    assert compensation.N == len(compensation.dataframe)
-    assert hasattr(compensation, "dataframe")
-    assert type(compensation.dataframe) is pandas.core.frame.DataFrame
-    assert all(compensation.dataframe.index == compensation.channels)
-    assert hasattr(compensation, "apply")
-    assert hasattr(compensation, "dataframe_as_html")
+def test_update_compensation(experiment, compensation):
+    """Test that the .update() method makes the correct call. Does not test
+    that the correct response is made; this should be done with an integration
+    test.
+    """
+    # patch the mocked response with the correct values
+    response = compensation._properties.copy()
+    response.update({"name": "newname"})
+    responses.add(
+        responses.PATCH,
+        base_url
+        + "experiments/5d64abe2ca9df61349ed8e78/compensations/{0}".format(
+            compensation._id
+        ),
+        json=response,
+    )
+    compensation.name = "newname"
+    compensation.update()
+    properties_tester(compensation)
+    assert json.loads(responses.calls[0].request.body) == compensation._properties

--- a/tests/unit/resources/test_experiment.py
+++ b/tests/unit/resources/test_experiment.py
@@ -1,10 +1,29 @@
 import os
+import json
 import responses
 import cellengine
 from cellengine.utils import helpers
 
 
 base_url = os.environ.get("CELLENGINE_DEVELOPMENT", "https://cellengine.com/api/v1/")
+
+
+@responses.activate
+def test_update_experiment(experiments):
+    """Tests updating experiment params"""
+    experiment = cellengine.Experiment(experiments[0])
+    response = experiments[0].copy()
+    response.update({"name": "new name"})
+    responses.add(
+        responses.PATCH,
+        base_url + "experiments/5d38a6f79fae87499999a74b",
+        json=response
+    )
+    assert experiment.name == "pytest_experiment"
+    experiment.name = "new name"
+    experiment.update()
+    assert experiment.name == "new name"
+    assert json.loads(responses.calls[0].request.body) == experiment._properties
 
 
 @responses.activate

--- a/tests/unit/resources/test_gates.py
+++ b/tests/unit/resources/test_gates.py
@@ -127,8 +127,28 @@ def test_create_multiple_gates(gates):
     assert type(all_gates) is list
 
 
-# def test_update_gate():
-#     pass
+@responses.activate
+def test_update_gate(experiment, rectangle_gate):
+    """Test that the .update() method makes the correct call. Does not test
+    that the correct response is made; this should be done with an integration
+    test.
+    """
+    gate = cellengine.Gate.create(rectangle_gate)
+    # patch the mocked response with the correct values
+    response = rectangle_gate.copy()
+    response.update({"name": "newname"})
+    responses.add(
+        responses.PATCH,
+        base_url
+        + "experiments/5d38a6f79fae87499999a74b/gates/{0}".format(
+            gate._id
+        ),
+        json=response,
+    )
+    gate.name = "newname"
+    gate.update()
+    gate_tester(gate)
+    assert json.loads(responses.calls[0].request.body) == gate._properties
 
 
 # def test_update_gate_family():

--- a/tests/unit/resources/test_population.py
+++ b/tests/unit/resources/test_population.py
@@ -3,7 +3,6 @@ import json
 import pytest
 import responses
 import cellengine
-from tests.unit.resources.test_gates import gate_tester
 
 
 base_url = os.environ.get("CELLENGINE_DEVELOPMENT", "https://cellengine.com/api/v1/")
@@ -34,15 +33,23 @@ def test_all_population_properties(population):
 
 @responses.activate
 def test_update_population(experiment, population, populations):
+    """Test that the .update() method makes the correct call. Does not test
+    that the correct response is made; this should be done with an integration
+    test.
+    """
+    # patch the mocked response with the correct values
+    response = population._properties.copy()
+    response.update({"name": "newname"})
     responses.add(
         responses.PATCH,
         base_url
         + "experiments/5d38a6f79fae87499999a74b/populations/{0}".format(population._id),
-        json=populations[0],
+        json=response,
     )
     population.name = "newname"
-    update_population = population.update()
-    test_all_population_properties(update_population)
+    population.update()
+    test_all_population_properties(population)
+    assert json.loads(responses.calls[0].request.body) == population._properties
 
 
 @responses.activate

--- a/tests/unit/test_base_methods.py
+++ b/tests/unit/test_base_methods.py
@@ -58,11 +58,9 @@ def test_base_update(experiments):
     )
     res = helpers.base_update(
         "experiments/5d64abe2ca9df61349ed8e78",
-        body={"name": "newname", "locked": True, "fullName": "Primity Bio"},
-        classname=cellengine.Experiment,
+        body={"name": "newname", "locked": True, "fullName": "Primity Bio"}
     )
-    assert type(res) is cellengine.Experiment
-    assert res.name == "pytest_experiment"
+    assert res['name'] == "pytest_experiment"
 
 
 @responses.activate


### PR DESCRIPTION
Adds an `.update()` method to the current resources. This calls `base_update`
with the resources path, and then updates the resources `_properties` dict with
the updated properties.

Tests confirm that the correct request is made, but NOT that the correct
response is returned by CellEngine.