### PR TITLE
More release fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           pip install mkdocstrings
           pip install mkdocs-material
       - name: Build site
-        run: mkdocs build
+        run: mkdocs build --strict
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/cellengine/payloads/gate_utils/ellipse_gate.py
+++ b/cellengine/payloads/gate_utils/ellipse_gate.py
@@ -27,9 +27,6 @@ def format_ellipse_gate(
     """Formats an ellipse gate for posting to the CellEngine API.
 
     Args:
-        experiment_id (str): The ID of the experiment to which to add the gate.
-            Use when calling this as a static method; not needed when calling
-            from an Experiment object
         x_channel (str): The name of the x channel to which the gate applies.
         y_channel (str): The name of the y channel to which the gate applies.
         name (str): The name of the gate

--- a/cellengine/payloads/gate_utils/polygon_gate.py
+++ b/cellengine/payloads/gate_utils/polygon_gate.py
@@ -24,9 +24,6 @@ def format_polygon_gate(
     """Formats a polygon gate for posting to the CE API.
 
     Args:
-        experiment_id (str): The ID of the experiment to which to add the gate.
-            Use when calling this as a static method; not needed when calling
-            from an Experiment object
         x_channel (str): The name of the x channel to which the gate applies.
         y_channel (str): The name of the y channel to which the gate applies.
         vertices (list): List of coordinates, like [[x,y], [x,y], ...]

--- a/cellengine/payloads/gate_utils/quadrant_gate.py
+++ b/cellengine/payloads/gate_utils/quadrant_gate.py
@@ -32,10 +32,6 @@ def format_quadrant_gate(
     lower-right), each with a unique gid and name.
 
     Args:
-
-        experiment_id (str): The ID of the experiment to which to add the gate.
-            Use when calling this as a static method; not needed when calling
-            from an Experiment object
         x_channel (str): The name of the x channel to which the gate applies.
         y_channel (str): The name of the y channel to which the gate applies.
         name (str): The name of the gate

--- a/cellengine/payloads/gate_utils/range_gate.py
+++ b/cellengine/payloads/gate_utils/range_gate.py
@@ -25,9 +25,6 @@ def format_range_gate(
     """Formats a range gate for posting to the CE API.
 
     Args:
-        experiment_id (str): The ID of the experiment to which to add the gate.
-            Use when calling this as a static method; not needed when calling
-            from an Experiment object
         x_channel (str): The name of the x channel to which the gate applies.
         name (str): The name of the gate
         x1 (float): The first x coordinate (after the channel's scale has been applied).

--- a/cellengine/payloads/gate_utils/rectangle_gate.py
+++ b/cellengine/payloads/gate_utils/rectangle_gate.py
@@ -27,9 +27,6 @@ def format_rectangle_gate(
     """Formats a rectangle gate for posting to the CE API.
 
     Args:
-        experiment_id (str): The ID of the experiment to which to add the gate.
-            Use when calling this as a static method; not needed when calling
-            from an Experiment object
         name (str): The name of the gate
         x_channel (float): The name of the x channel to which the gate applies.
         y_channel (float): The name of the y channel to which the gate applies.

--- a/cellengine/payloads/gate_utils/split_gate.py
+++ b/cellengine/payloads/gate_utils/split_gate.py
@@ -29,9 +29,6 @@ def format_split_gate(
     each with a unique gid and name.
 
     Args:
-        experiment_id (str): The ID of the experiment to which to add the gate.
-            Use when calling this as a static method; not needed when calling
-            from an Experiment object
         x_channel (str): The name of the x channel to which the gate applies.
         name (str): The name of the gate.
         x (float): The x coordinate of the center point (after the channel's scale has

--- a/cellengine/payloads/population.py
+++ b/cellengine/payloads/population.py
@@ -19,7 +19,7 @@ class _Population(object):
 
     gates = GetSet("gates")
 
-    terminal_gate_gid = GetSet("terminalGateId")
+    terminal_gate_gid = GetSet("terminalGateGid")
 
     parent_id = GetSet("parentId")
 

--- a/cellengine/resources/experiment.py
+++ b/cellengine/resources/experiment.py
@@ -405,22 +405,22 @@ class Experiment(_Experiment):
         post_body = format_quadrant_gate(kwargs.pop("self")._id, **kwargs)
         return ce.APIClient().post_gate(self._id, post_body)
 
-    def create_population(self, population: Dict):
+    def create_population(self, population: Dict) -> Population:
         """Create a complex population
 
         Args:
-            population (dict): The population to create. Use the
-                `ComplexPopulationBuilder` to construct a complex population.
+            population (dict): The population to create.
+                Use the `ComplexPopulationBuilder` to construct a complex population.
+
+        Examples:
+            experiment.create_population({
+                "name": name,
+                "terminalGateGid": GID,
+                "parentId": parent._id,
+                "gates": json.dumps({"$and": AND_GATES})
+            })
 
         Returns:
             Population: A created complex population.
         """
-        raise NotImplementedError(
-            """
-            This method has not been implemented yet.
-            Several CellEngine features, such as deletion
-            of complex populations, are currently
-            unavailable.
-            """
-        )
         return ce.APIClient().post_population(self._id, population)

--- a/cellengine/resources/experiment.py
+++ b/cellengine/resources/experiment.py
@@ -254,8 +254,8 @@ class Experiment(_Experiment):
         self, _id: str = None, gid: str = None, exclude: bool = None
     ) -> None:
         """Delete a gate or gate family.
-
-        See [`APIClient.delete_gate`][cellengine.utils.api_client.APIClient.APIClient.delete_gate]
+        See the
+        [`APIClient`][cellengine.utils.api_client.APIClient.APIClient.delete_gate]
         for more information.
         """
         return ce.APIClient().delete_gate(self._id, _id, gid, exclude)

--- a/cellengine/resources/experiment.py
+++ b/cellengine/resources/experiment.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import inspect
+from math import pi
 from custom_inherit import doc_inherit
 from typing import Optional, Dict, Union, List
 
@@ -248,37 +250,159 @@ class Experiment(_Experiment):
         return Gate.bulk_create(self._id, gates)
 
     @doc_inherit(Gate.delete_gates)
-    def delete_gates(self, _id=None, gid=None, exclude=None) -> None:
+    def delete_gate(
+        self, _id: str = None, gid: str = None, exclude: bool = None
+    ) -> None:
+        """Delete a gate or gate family.
+
+        See [`APIClient.delete_gate`][cellengine.utils.api_client.APIClient.APIClient.delete_gate]
+        for more information.
+        """
         return ce.APIClient().delete_gate(self._id, _id, gid, exclude)
 
     @doc_inherit(format_rectangle_gate)
-    def create_rectangle_gate(self, *args, **kwargs) -> RectangleGate:
-        post_body = format_rectangle_gate(self._id, *args, **kwargs)
+    def create_rectangle_gate(
+        self,
+        x_channel: str,
+        y_channel: str,
+        name: str,
+        x1: float,
+        x2: float,
+        y1: float,
+        y2: float,
+        label: List[str] = [],
+        gid: str = None,
+        locked: bool = False,
+        parent_population_id: str = None,
+        parent_population: str = None,
+        tailored_per_file: bool = False,
+        fcs_file_id: str = None,
+        fcs_file: str = None,
+        create_population: bool = True,
+    ) -> RectangleGate:
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        kwargs = {arg: values.get(arg, None) for arg in args}
+        post_body = format_rectangle_gate(kwargs.pop("self")._id, **kwargs)
         return ce.APIClient().post_gate(self._id, post_body)
 
     @doc_inherit(format_polygon_gate)
-    def create_polygon_gate(self, *args, **kwargs) -> PolygonGate:
-        post_body = format_polygon_gate(self._id, *args, **kwargs)
+    def create_polygon_gate(
+        self,
+        x_channel: str,
+        y_channel: str,
+        name: str,
+        vertices: List[float],
+        label: List[str] = [],
+        gid: str = None,
+        locked: bool = False,
+        parent_population_id: str = None,
+        parent_population: str = None,
+        tailored_per_file: bool = False,
+        fcs_file_id: str = None,
+        fcs_file: str = None,
+        create_population: bool = True,
+    ) -> PolygonGate:
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        kwargs = {arg: values.get(arg, None) for arg in args}
+        post_body = format_polygon_gate(kwargs.pop("self")._id, **kwargs)
         return ce.APIClient().post_gate(self._id, post_body)
 
     @doc_inherit(format_ellipse_gate)
-    def create_ellipse_gate(self, *args, **kwargs) -> EllipseGate:
-        post_body = format_ellipse_gate(self._id, *args, **kwargs)
+    def create_ellipse_gate(
+        self,
+        x_channel: str,
+        y_channel: str,
+        name: str,
+        x: float,
+        y: float,
+        angle: float,
+        major: float,
+        minor: float,
+        label: List = [],
+        gid: str = None,
+        locked: bool = False,
+        parent_population_id: str = None,
+        parent_population: str = None,
+        tailored_per_file: bool = False,
+        fcs_file_id: str = None,
+        fcs_file: str = None,
+        create_population: bool = True,
+    ) -> EllipseGate:
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        kwargs = {arg: values.get(arg, None) for arg in args}
+        post_body = format_ellipse_gate(kwargs.pop("self")._id, **kwargs)
         return ce.APIClient().post_gate(self._id, post_body)
 
     @doc_inherit(format_range_gate)
-    def create_range_gate(self, *args, **kwargs) -> RangeGate:
-        post_body = format_range_gate(self._id, *args, **kwargs)
+    def create_range_gate(
+        self,
+        x_channel: str,
+        name: str,
+        x1: float,
+        x2: float,
+        y: float = 0.5,
+        label: List[str] = [],
+        gid: str = None,
+        locked: bool = False,
+        parent_population_id: str = None,
+        parent_population: str = None,
+        tailored_per_file: bool = False,
+        fcs_file_id: str = None,
+        fcs_file: str = None,
+        create_population: bool = True,
+    ) -> RangeGate:
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        kwargs = {arg: values.get(arg, None) for arg in args}
+        post_body = format_range_gate(kwargs.pop("self")._id, **kwargs)
         return ce.APIClient().post_gate(self._id, post_body)
 
     @doc_inherit(format_split_gate)
-    def create_split_gate(self, *args, **kwargs) -> SplitGate:
-        post_body = format_split_gate(self._id, *args, **kwargs)
+    def create_split_gate(
+        self,
+        x_channel: str,
+        name: str,
+        x: str,
+        y: float = 0.5,
+        labels: List[str] = [],
+        gid: str = None,
+        gids: List[str] = None,
+        locked: bool = False,
+        parent_population_id: str = None,
+        parent_population: str = None,
+        tailored_per_file: bool = False,
+        fcs_file_id: str = None,
+        fcs_file: str = None,
+        create_population: bool = True,
+    ) -> SplitGate:
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        kwargs = {arg: values.get(arg, None) for arg in args}
+        post_body = format_split_gate(kwargs.pop("self")._id, **kwargs)
         return ce.APIClient().post_gate(self._id, post_body)
 
     @doc_inherit(format_quadrant_gate)
-    def create_quadrant_gate(self, *args, **kwargs) -> QuadrantGate:
-        post_body = format_quadrant_gate(self._id, *args, **kwargs)
+    def create_quadrant_gate(
+        self,
+        x_channel: str,
+        y_channel: str,
+        name: str,
+        x: float,
+        y: float,
+        labels: List[str] = [],
+        skewable: bool = False,
+        angles: List[float] = [0, pi / 2, pi, 3 * pi / 2],
+        gid: str = None,
+        gids: List[str] = None,
+        locked: bool = False,
+        parent_population_id: str = None,
+        parent_population: str = None,
+        tailored_per_file: bool = False,
+        fcs_file_id: str = None,
+        fcs_file: str = None,
+        create_population: bool = True,
+    ) -> QuadrantGate:
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        kwargs = {arg: values.get(arg, None) for arg in args}
+        post_body = format_quadrant_gate(kwargs.pop("self")._id, **kwargs)
         return ce.APIClient().post_gate(self._id, post_body)
 
     def create_population(self, population: Dict):

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -103,7 +103,6 @@ class FcsFile(_FcsFile):
     def delete(self):
         return ce.APIClient().delete_entity(self.experiment_id, "fcsfiles", self._id)
 
-    @doc_inherit(Plot.get)
     def plot(
         self,
         x_channel: str,
@@ -113,6 +112,10 @@ class FcsFile(_FcsFile):
         population_id: str = None,
         **kwargs,
     ) -> Plot:
+        """Buid a plot for an FcsFile.
+
+        See [`Plot.get`][cellengine.resources.plot.Plot.get] for more information.
+        """
         plot = Plot.get(
             experiment_id=self.experiment_id,
             fcs_file_id=self._id,

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -38,9 +38,9 @@ class FcsFile(_FcsFile):
         filename: str = None,
         add_file_number: bool = False,
         add_event_number: bool = False,
-        pre_subsample_n: float = None,
+        pre_subsample_n: int = None,
         pre_subsample_p: float = None,
-        seed: float = None,
+        seed: int = None,
     ) -> FcsFile:
         """Creates an FCS file by copying, concatenating and/or subsampling
         existing file(s) from this or other experiments.
@@ -61,11 +61,11 @@ class FcsFile(_FcsFile):
                 exported file. This number corresponds to the index of the event in
                 the original file; when concatenating files, the same event number
                 will appear more than once.
-            pre_subsample_n (float): Randomly subsample the file to contain
+            pre_subsample_n (int): Randomly subsample the file to contain
                 this many events.
             pre_subsample_p (float): Randomly subsample the file to contain
                 this percent of events (0 to 1).
-            seed (float): Seed for random number generator used for subsampling.
+            seed (int): Seed for random number generator used for subsampling.
                 Use for deterministic (reproducible) subsampling. If omitted, a
                 pseudo-random value is used.
 
@@ -159,8 +159,8 @@ class FcsFile(_FcsFile):
                     For FCS format, the numerical values will be unchanged, but the
                     file header will contain the compensation as the spill string
                     (file-internal compensation).
-                - compensationId (int): Required if populationId is specified.
-                    Compensation to use for gating.
+                - compensationId ([int, str]): Required if populationId is
+                    specified. Compensation to use for gating.
                 - headers (bool): For TSV format only. If true, a header row
                     containing the channel names will be included.
                 - original (bool): If true, the returned file will be
@@ -184,7 +184,7 @@ class FcsFile(_FcsFile):
                     this many events before gating.
                 - preSubsampleP (float): Randomly subsample the file to contain
                     this percent of events (0 to 1) before gating.
-                - seed: (float): Seed for random number generator used for
+                - seed: (int): Seed for random number generator used for
                     subsampling. Use for deterministic (reproducible) subsampling.
                     If omitted, a pseudo-random value is used.
                 - addEventNumber (bool): Add an event number column to the
@@ -193,7 +193,6 @@ class FcsFile(_FcsFile):
                     original file.
 
         Returns: None; updates the self.events property.
-
         """
 
         fresp = ce.APIClient().download_fcs_file(
@@ -201,6 +200,3 @@ class FcsFile(_FcsFile):
         )
         parser = fcsparser.api.FCSParser.from_data(fresp)
         self._events = pandas.DataFrame(parser.data, columns=parser.channel_names_n)
-
-        """
-        """

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -39,9 +39,9 @@ class FcsFile(_FcsFile):
         filename: str = None,
         add_file_number: bool = False,
         add_event_number: bool = False,
-        pre_subsample_n: int = None,
-        pre_subsample_p: int = None,
-        seed: int = None,
+        pre_subsample_n: float = None,
+        pre_subsample_p: float = None,
+        seed: float = None,
     ) -> FcsFile:
         """Creates an FCS file by copying, concatenating and/or subsampling
         existing file(s) from this or other experiments.
@@ -58,15 +58,15 @@ class FcsFile(_FcsFile):
             add_file_number (optional): If
                 concatenating files, adds a file number channel to the
                 resulting file.
-            add_event_number (optional): Add an event number column to the
+            add_event_number (bool): Add an event number column to the
                 exported file. This number corresponds to the index of the event in
                 the original file; when concatenating files, the same event number
                 will appear more than once.
-            pre_subsample_n (optional): Randomly subsample the file to contain
+            pre_subsample_n (float): Randomly subsample the file to contain
                 this many events.
-            pre_subsample_p (optional): Randomly subsample the file to contain
+            pre_subsample_p (float): Randomly subsample the file to contain
                 this percent of events (0 to 1).
-            seed (optional): Seed for random number generator used for subsampling.
+            seed (float): Seed for random number generator used for subsampling.
                 Use for deterministic (reproducible) subsampling. If omitted, a
                 pseudo-random value is used.
 
@@ -137,23 +137,23 @@ class FcsFile(_FcsFile):
     def events(self, events):
         self._events = events
 
-    def get_events(self, **params):
+    def get_events(self, **kwargs):
         """
         Fetch a DataFrame containing this file's data.
 
         Args:
-            params (Dict): keyword arguments of form:
-                compensatedQ (bool): If true, applies the compensation
+            **kwargs:
+                - compensatedQ (bool): If true, applies the compensation
                     specified in compensationId to the exported events. For TSV
                     format, the numerical values will be the compensated values.
                     For FCS format, the numerical values will be unchanged, but the
                     file header will contain the compensation as the spill string
                     (file-internal compensation).
-                compensationId (str): Required if populationId is specified.
+                - compensationId (int): Required if populationId is specified.
                     Compensation to use for gating.
-                headers (bool): For TSV format only. If true, a header row
+                - headers (bool): For TSV format only. If true, a header row
                     containing the channel names will be included.
-                original (bool): If true, the returned file will be
+                - original (bool): If true, the returned file will be
                     byte-for-byte identical to the originally uploaded file. If
                     false or unspecified (and compensatedQ is false, populationId
                     is unspecified and all subsampling parameters are unspecified),
@@ -164,28 +164,33 @@ class FcsFile(_FcsFile):
                     appended to the end of the original file will be stripped. This
                     parameter takes precedence over compensatedQ, populationId and
                     the subsampling parameters.
-                populationId (str): If provided, only events from this
+                - populationId (str): If provided, only events from this
                     population will be included in the output file.
-                postSubsampleN (int): Randomly subsample the file to contain
+                - postSubsampleN (int): Randomly subsample the file to contain
                     this many events after gating.
-                postSubsampleP (float): Randomly subsample the file to contain
+                - postSubsampleP (float): Randomly subsample the file to contain
                     this percent of events (0 to 1) after gating.
-                preSubsampleN (int): Randomly subsample the file to contain
+                - preSubsampleN (int): Randomly subsample the file to contain
                     this many events before gating.
-                preSubsampleP (float): Randomly subsample the file to contain
+                - preSubsampleP (float): Randomly subsample the file to contain
                     this percent of events (0 to 1) before gating.
-                seed: (float): Seed for random number generator used for
+                - seed: (float): Seed for random number generator used for
                     subsampling. Use for deterministic (reproducible) subsampling.
                     If omitted, a pseudo-random value is used.
-                addEventNumber (bool): Add an event number column to the
+                - addEventNumber (bool): Add an event number column to the
                     exported file. When a populationId is specified (when gating),
                     this number corresponds to the index of the event in the
                     original file.
 
         Returns: None; updates the self.events property.
+
         """
+
         fresp = ce.APIClient().download_fcs_file(
-            self.experiment_id, self._id, params=params
+            self.experiment_id, self._id, params=dict(kwargs)
         )
         parser = fcsparser.api.FCSParser.from_data(fresp)
         self._events = pandas.DataFrame(parser.data, columns=parser.channel_names_n)
+
+        """
+        """

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -105,15 +105,23 @@ class FcsFile(_FcsFile):
 
     @doc_inherit(Plot.get)
     def plot(
-        self, x_channel: str, y_channel: str, plot_type: str, properties: Dict = None
+        self,
+        x_channel: str,
+        y_channel: str,
+        plot_type: str,
+        z_channel: str = None,
+        population_id: str = None,
+        **kwargs,
     ) -> Plot:
         plot = Plot.get(
             experiment_id=self.experiment_id,
             fcs_file_id=self._id,
+            plot_type=plot_type,
             x_channel=x_channel,
             y_channel=y_channel,
-            plot_type=plot_type,
-            properties=properties,
+            z_channel=z_channel,
+            population_id=population_id,
+            **kwargs,
         )
         return plot
 

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-from typing import List, Dict
-from custom_inherit import doc_inherit
+from typing import List
 import fcsparser
 import pandas
 

--- a/cellengine/resources/gate.py
+++ b/cellengine/resources/gate.py
@@ -3,6 +3,7 @@ import attr
 import importlib
 from typing import Dict, List, Optional
 from math import pi
+from custom_inherit import doc_inherit
 
 import cellengine as ce
 from cellengine.utils.helpers import get_args_as_kwargs
@@ -181,6 +182,7 @@ class RectangleGate(Gate):
     """Basic concrete class for Rectangle gates"""
 
     @classmethod
+    @doc_inherit(format_rectangle_gate)
     def create(
         cls,
         experiment_id: str,
@@ -200,7 +202,7 @@ class RectangleGate(Gate):
         fcs_file_id: str = None,
         fcs_file: str = None,
         create_population: bool = True,
-    ):
+    ) -> RectangleGate:
         g = format_rectangle_gate(**get_args_as_kwargs(cls, locals()))
         return cls(g)
 
@@ -209,6 +211,7 @@ class PolygonGate(Gate):
     """Basic concrete class for polygon gates"""
 
     @classmethod
+    @doc_inherit(format_polygon_gate)
     def create(
         cls,
         experiment_id: str,
@@ -225,7 +228,7 @@ class PolygonGate(Gate):
         fcs_file_id: str = None,
         fcs_file: str = None,
         create_population: bool = True,
-    ):
+    ) -> PolygonGate:
         g = format_polygon_gate(**get_args_as_kwargs(cls, locals()))
         return cls(g)
 
@@ -234,6 +237,7 @@ class EllipseGate(Gate):
     """Basic concrete class for ellipse gates"""
 
     @classmethod
+    @doc_inherit(format_ellipse_gate)
     def create(
         cls,
         experiment_id: str,
@@ -254,7 +258,7 @@ class EllipseGate(Gate):
         fcs_file_id: str = None,
         fcs_file: str = None,
         create_population: bool = True,
-    ):
+    ) -> EllipseGate:
         g = format_ellipse_gate(**get_args_as_kwargs(cls, locals()))
         return cls(g)
 
@@ -263,6 +267,7 @@ class RangeGate(Gate):
     """Basic concrete class for range gates"""
 
     @classmethod
+    @doc_inherit(format_range_gate)
     def create(
         cls,
         experiment_id: str,
@@ -280,7 +285,7 @@ class RangeGate(Gate):
         fcs_file_id: str = None,
         fcs_file: str = None,
         create_population: bool = True,
-    ):
+    ) -> RangeGate:
         g = format_range_gate(**get_args_as_kwargs(cls, locals()))
         return cls(g)
 
@@ -289,6 +294,7 @@ class QuadrantGate(Gate):
     """Basic concrete class for quadrant gates"""
 
     @classmethod
+    @doc_inherit(format_quadrant_gate)
     def create(
         cls,
         experiment_id: str,
@@ -309,7 +315,7 @@ class QuadrantGate(Gate):
         fcs_file_id: str = None,
         fcs_file: str = None,
         create_population: bool = True,
-    ):
+    ) -> QuadrantGate:
         g = format_quadrant_gate(**get_args_as_kwargs(cls, locals()))
         return cls(g)
 
@@ -318,6 +324,7 @@ class SplitGate(Gate):
     """Basic concrete class for split gates"""
 
     @classmethod
+    @doc_inherit(format_split_gate)
     def create(
         cls,
         experiment_id: str,
@@ -335,6 +342,6 @@ class SplitGate(Gate):
         fcs_file_id: str = None,
         fcs_file: str = None,
         create_population: bool = True,
-    ):
+    ) -> SplitGate:
         g = format_split_gate(**get_args_as_kwargs(cls, locals()))
         return cls(g)

--- a/cellengine/resources/plot.py
+++ b/cellengine/resources/plot.py
@@ -18,27 +18,27 @@ class Plot(_Plot):
     @classmethod
     def get(
         cls,
-        experiment_id,
+        experiment_id: str,
         fcs_file_id: str,
         plot_type: str,
         x_channel: str,
         y_channel: str,
         z_channel: str = None,
         population_id: str = None,
-        as_dict=False,
+        as_dict: bool = False,
         **kwargs,
     ) -> Plot:
         """
         Args:
-            experiment_id (str): ID of the experiment to which the file belongs.
-            fcs_file_id (str): ID of file for which to build a plot.
-            plot_type (str): "contour", "dot", "density" or
+            experiment_id: ID of the experiment to which the file belongs.
+            fcs_file_id: ID of file for which to build a plot.
+            plot_type: "contour", "dot", "density" or
                 "histogram" (case-insensitive)
-            x_channel (str): X channel name.
-            y_channel (str): (for 2D plots) Y channel name.
-            z_channel (str): (for dot plots colored by a 3rd channel)
+            x_channel: X channel name.
+            y_channel: (for 2D plots) Y channel name.
+            z_channel: (for dot plots colored by a 3rd channel)
                 Color channel name.
-            population_id (ID): Defaults to ungated.
+            population_id: Defaults to ungated.
             **kwargs (Dict):
                 - axesQ (bool): Display axes lines. Defaults to true.
                 - axisLabelsQ (bool): Display axis labels. Defaults to true.

--- a/cellengine/resources/plot.py
+++ b/cellengine/resources/plot.py
@@ -39,51 +39,50 @@ class Plot(_Plot):
             z_channel (str): (for dot plots colored by a 3rd channel)
                 Color channel name.
             population_id (ID): Defaults to ungated.
-            kwargs (Dict): Optional query parameters, camelCased.
-
-                    axesQ (bool): Display axes lines. Defaults to true.
-                    axisLabelsQ (bool): Display axis labels. Defaults to true.
-                    compensation (ID): Compensation to use for gating and display.
-                    color (str): Case-insensitive string in the format
-                        #rgb, #rgba, #rrggbb or #rrggbbaa. The foreground color, i.e.
-                        color of curve in "histogram" plots and dots in "dot" plots.
-                    gateLabel (str): One of "eventcount", "mean", "median",
-                        "percent", "mad", "cv", "stddev", "geometricmean",
-                        "name", "none".
-                    gateLabelFontSize (float): Font size for gate labels.
-                    height (int): Image height. Defaults to 228.
-                    percentileStart (float): For contour plots, the percentile of the
-                        first contour.
-                    percentileStep (float): For contour plots, the percentile
-                        step between each contour.
-                    postSubsampleN (int): Randomly subsample the file to contain
-                        this many events after gating.
-                    postSubsampleP (float): Randomly subsample the file to contain this
-                        percent of events (0 to 1) after gating.
-                    preSubsampleN (int): Randomly subsample the file to contain this
-                        many events before gating.
-                    preSubsampleP (float): Randomly subsample the file to contain this
-                        percent of events (0 to 1) before gating.
-                    renderGates (bool): Render gates into the image.
-                    seed (float): Seed for random number generator used for
-                        subsampling. Use for deterministic (reproducible) subsampling.
-                        If omitted, a pseudo-random value is used.
-                    smoothing (float): For density and contour plots, adjusts the
-                    strokeThickness (float): The thickness of histogram and contour
-                        plot lines. Defaults to 1.
-                    tickLabelsQ (bool): Display tick labels. Defaults to false.
-                    ticksQ (bool): Display ticks. Defaults to true.
-                    width (int): Image width. Defaults to 228.
-                    xAxisLabelQ (bool): Display x axis label. Overrides axisLabelsQ.
-                    xAxisQ (bool): Display x axis line. Overrides axesQ.
-                    xTickLabelsQ (bool): Display x tick labels. overrides tickLabelsQ.
-                    xTicksQ (bool): Display x ticks. Overrides ticksQ.
-                    yAxisLabelQ (bool): Display y axis label. Overrides axisLabelsQ.
-                        amount of smoothing. Defaults to 0 (no smoothing). Set to 1 for
-                        typical smoothing. Higher values (up to 10) increase smoothing.
-                    yAxisQ (bool): Display y axis line. Overrides axesQ.
-                    yTickLabelsQ (bool): Display y tick labels. Overrides tickLabelsQ.
-                    yTicksQ (bool): Display y ticks. Overrides ticksQ.
+            **kwargs (Dict):
+                - axesQ (bool): Display axes lines. Defaults to true.
+                - axisLabelsQ (bool): Display axis labels. Defaults to true.
+                - compensation (ID): Compensation to use for gating and display.
+                - color (str): Case-insensitive string in the format
+                    #rgb, #rgba, #rrggbb or #rrggbbaa. The foreground color, i.e.
+                    color of curve in "histogram" plots and dots in "dot" plots.
+                - gateLabel (str): One of "eventcount", "mean", "median",
+                    "percent", "mad", "cv", "stddev", "geometricmean",
+                    "name", "none".
+                - gateLabelFontSize (float): Font size for gate labels.
+                - height (int): Image height. Defaults to 228.
+                - percentileStart (float): For contour plots, the percentile of the
+                    first contour.
+                - percentileStep (float): For contour plots, the percentile
+                    step between each contour.
+                - postSubsampleN (int): Randomly subsample the file to contain
+                    this many events after gating.
+                - postSubsampleP (float): Randomly subsample the file to contain this
+                    percent of events (0 to 1) after gating.
+                - preSubsampleN (int): Randomly subsample the file to contain this
+                    many events before gating.
+                - preSubsampleP (float): Randomly subsample the file to contain this
+                    percent of events (0 to 1) before gating.
+                - renderGates (bool): Render gates into the image.
+                - seed (float): Seed for random number generator used for
+                    subsampling. Use for deterministic (reproducible) subsampling.
+                    If omitted, a pseudo-random value is used.
+                - smoothing (float): For density and contour plots, adjusts the
+                - strokeThickness (float): The thickness of histogram and contour
+                    plot lines. Defaults to 1.
+                - tickLabelsQ (bool): Display tick labels. Defaults to false.
+                - ticksQ (bool): Display ticks. Defaults to true.
+                - width (int): Image width. Defaults to 228.
+                - xAxisLabelQ (bool): Display x axis label. Overrides axisLabelsQ.
+                - xAxisQ (bool): Display x axis line. Overrides axesQ.
+                - xTickLabelsQ (bool): Display x tick labels. overrides tickLabelsQ.
+                - xTicksQ (bool): Display x ticks. Overrides ticksQ.
+                - yAxisLabelQ (bool): Display y axis label. Overrides axisLabelsQ.
+                    amount of smoothing. Defaults to 0 (no smoothing). Set to 1 for
+                    typical smoothing. Higher values (up to 10) increase smoothing.
+                - yAxisQ (bool): Display y axis line. Overrides axesQ.
+                - yTickLabelsQ (bool): Display y tick labels. Overrides tickLabelsQ.
+                - yTicksQ (bool): Display y ticks. Overrides ticksQ.
         """
         properties = None
         if kwargs:

--- a/cellengine/resources/plot.py
+++ b/cellengine/resources/plot.py
@@ -64,7 +64,7 @@ class Plot(_Plot):
                 - preSubsampleP (float): Randomly subsample the file to contain this
                     percent of events (0 to 1) before gating.
                 - renderGates (bool): Render gates into the image.
-                - seed (float): Seed for random number generator used for
+                - seed (int): Seed for random number generator used for
                     subsampling. Use for deterministic (reproducible) subsampling.
                     If omitted, a pseudo-random value is used.
                 - smoothing (float): For density and contour plots, adjusts the

--- a/cellengine/utils/api_client/APIClient.py
+++ b/cellengine/utils/api_client/APIClient.py
@@ -280,50 +280,49 @@ class APIClient(BaseAPIClient, metaclass=Singleton):
         Parameters:
             experiment_id (str): ID of the experiment
             fcs_file_id (str): ID of the FcsFile
-            kwargs (Dict): Optional query parameters, camelCased.
-
-                    compensatedQ (bool): If true, applies the compensation
-                      specified in compensationId to the exported events. For
-                      TSV format, the numerical values will be the compensated
-                      values.  For FCS format, the numerical values will be
-                      unchanged, but the file header will contain the
-                      compensation as the spill string (file-internal
-                      compensation).
-                    compensationId (str, optional): Required if populationId is
-                        specified. Compensation to use for gating.
-                    headers (bool): For TSV format only. If true, a header row
-                      containing the channel names will be included.
-                    original (bool): If true, the returned file will be
-                        byte-for-byte identical to the originally uploaded
-                        file. If false or unspecified (and compensatedQ is
-                        false, populationId is unspecified and all subsampling
-                        parameters are unspecified), the returned file will
-                        contain essentially the same data as the originally
-                        uploaded file, but may not be byte-for-byte identical.
-                        For example, the byte ordering of the DATA segment will
-                        always be little-endian and any extraneous information
-                        appended to the end of the original file will be
-                        stripped. This parameter takes precedence over
-                        compensatedQ, populationId and the subsampling
-                        parameters.
-                    populationId (str): If provided, only events from this
-                        population will be included in the output file.
-                    postSubsampleN (int): Randomly subsample the file to
-                        contain this many events after gating.
-                    postSubsampleP (float): Randomly subsample the file to
-                        contain this percent of events (0 to 1) after gating.
-                    preSubsampleN (int): Randomly subsample the file to contain
-                        this many events before gating.
-                    preSubsampleP (float): Randomly subsample the file to
-                        contain this percent of events (0 to 1) before gating.
-                    seed: (float): Seed for random number generator used for
-                        subsampling. Use for deterministic (reproducible)
-                        subsampling.  If omitted, a pseudo-random value is
-                        used.
-                    addEventNumber (bool): Add an event number column to the
-                        exported file. When a populationId is specified
-                        (when gating), this number corresponds to the index of
-                        the event in the original file.
+            kwargs:
+                - compensatedQ (bool): If true, applies the compensation
+                  specified in compensationId to the exported events. For
+                  TSV format, the numerical values will be the compensated
+                  values.  For FCS format, the numerical values will be
+                  unchanged, but the file header will contain the
+                  compensation as the spill string (file-internal
+                  compensation).
+                - compensationId (str, optional): Required if populationId is
+                    specified. Compensation to use for gating.
+                - headers (bool): For TSV format only. If true, a header row
+                  containing the channel names will be included.
+                - original (bool): If true, the returned file will be
+                    byte-for-byte identical to the originally uploaded
+                    file. If false or unspecified (and compensatedQ is
+                    false, populationId is unspecified and all subsampling
+                    parameters are unspecified), the returned file will
+                    contain essentially the same data as the originally
+                    uploaded file, but may not be byte-for-byte identical.
+                    For example, the byte ordering of the DATA segment will
+                    always be little-endian and any extraneous information
+                    appended to the end of the original file will be
+                    stripped. This parameter takes precedence over
+                    compensatedQ, populationId and the subsampling
+                    parameters.
+                - populationId (str): If provided, only events from this
+                    population will be included in the output file.
+                - postSubsampleN (int): Randomly subsample the file to
+                    contain this many events after gating.
+                - postSubsampleP (float): Randomly subsample the file to
+                    contain this percent of events (0 to 1) after gating.
+                - preSubsampleN (int): Randomly subsample the file to contain
+                    this many events before gating.
+                - preSubsampleP (float): Randomly subsample the file to
+                    contain this percent of events (0 to 1) before gating.
+                - seed: (float): Seed for random number generator used for
+                    subsampling. Use for deterministic (reproducible)
+                    subsampling.  If omitted, a pseudo-random value is
+                    used.
+                - addEventNumber (bool): Add an event number column to the
+                    exported file. When a populationId is specified
+                    (when gating), this number corresponds to the index of
+                    the event in the original file.
         """
         params = {}
         if kwargs:

--- a/cellengine/utils/api_client/APIClient.py
+++ b/cellengine/utils/api_client/APIClient.py
@@ -347,7 +347,9 @@ class APIClient(BaseAPIClient, metaclass=Singleton):
             return gate
         return Gate.factory(gate)
 
-    def delete_gate(self, experiment_id: str, _id=None, gid=None, exclude=None) -> None:
+    def delete_gate(
+        self, experiment_id: str, _id: str = None, gid: str = None, exclude: bool = None
+    ) -> None:
         """Deletes a gate or a tailored gate family.
 
         Specify the top-level gid when working with compound gates (specifying
@@ -357,9 +359,10 @@ class APIClient(BaseAPIClient, metaclass=Singleton):
         a static method from cellengine.Gate or from an Experiment instance.
 
         Args:
-            experiment_id (str): ID of experiment.
-            _id (str): ID of gate family.
-            exclude (str): Gate ID to exclude from deletion.
+            experiment_id: ID of experiment.
+            _id: ID of the gate to delete.
+            gid: ID of gate family to delte.
+            exclude: Gate ID to exclude from deletion.
 
         Example:
             ```python

--- a/cellengine/utils/api_client/APIClient.py
+++ b/cellengine/utils/api_client/APIClient.py
@@ -315,7 +315,7 @@ class APIClient(BaseAPIClient, metaclass=Singleton):
                     this many events before gating.
                 - preSubsampleP (float): Randomly subsample the file to
                     contain this percent of events (0 to 1) before gating.
-                - seed: (float): Seed for random number generator used for
+                - seed: (int): Seed for random number generator used for
                     subsampling. Use for deterministic (reproducible)
                     subsampling.  If omitted, a pseudo-random value is
                     used.
@@ -348,7 +348,7 @@ class APIClient(BaseAPIClient, metaclass=Singleton):
         return Gate.factory(gate)
 
     def delete_gate(
-        self, experiment_id: str, _id: str = None, gid: str = None, exclude: bool = None
+        self, experiment_id: str, _id: str = None, gid: str = None, exclude: str = None
     ) -> None:
         """Deletes a gate or a tailored gate family.
 

--- a/cellengine/utils/api_client/APIClient.py
+++ b/cellengine/utils/api_client/APIClient.py
@@ -22,30 +22,30 @@ from cellengine.resources.scaleset import ScaleSet
 class APIClient(BaseAPIClient, metaclass=Singleton):
     _API_NAME = "CellEngine Python Toolkit"
 
-    def __init__(self, user_name=None, password=None, token=None):
+    def __init__(self, username=None, password=None, token=None):
         super(APIClient, self).__init__()
         self.base_url = os.environ.get(
             "CELLENGINE_BASE_URL", "https://cellengine.com/api/v1"
         )
-        self.user_name = user_name
+        self.username = username
         self.password = password or os.environ.get("CELLENGINE_PASSWORD")
         self.token = token or os.environ.get("CELLENGINE_AUTH_TOKEN")
         self.user_id = None
         self.flags = None
         self.authenticated = self._authenticate(
-            self.user_name, self.password, self.token
+            self.username, self.password, self.token
         )
 
         self.cache_info = self._get_id_by_name.cache_info
         self.cache_clear = self._get_id_by_name.cache_clear
 
     def __repr__(self):
-        if self.user_name:
-            return f"Client(user={self.user_name})"
+        if self.username:
+            return f"Client(user={self.username})"
         else:
             return "Client(TOKEN)"
 
-    def _authenticate(self, user_name, password, token):
+    def _authenticate(self, username, password, token):
         """Authenticate with the CellEngine API.
 
         There are two ways of authenticating:
@@ -58,13 +58,13 @@ class APIClient(BaseAPIClient, metaclass=Singleton):
             password: Password for login
             token: Authentication token; may be passed instead of username and password
         """
-        if user_name:
-            self.user_name = user_name
+        if username:
+            self.username = username
             self.password = password or getpass()
 
             res = self._post(
                 f"{self.base_url}/signin",
-                {"username": self.user_name, "password": self.password},
+                {"username": self.username, "password": self.password},
             )
 
             self.token = res["token"]

--- a/docs/api_client.md
+++ b/docs/api_client.md
@@ -41,7 +41,7 @@ GitHub](https://github.com/primitybio/cellengine-python-toolkit/issues).
 
 ## Properties
 - base_url
-- user_name
+- username
 - password
 - token
 - user_id

--- a/docs/statistics.md
+++ b/docs/statistics.md
@@ -4,7 +4,10 @@
 
 Programmatically use CellEngine for statistical analysis.
 
+### APIClient.get_statistics
+
 ::: cellengine.APIClient.get_statistics
     rendering:
-      show_source: true
+      show_source: false
       show_object_full_path: false
+      show_root_heading: false

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "requests~=2.22",
         "requests-toolbelt~=0.9",
         "urllib3~=1.25",
-        "custom_inherit~=2.2",
+        "custom_inherit~=2.3",
     ],
     extras_require={"interactive": ["Pillow~=7.0"]},
     tests_require=["pytest", "pytest-vcr"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def client(ENDPOINT_BASE):
             },
             status=200,
         )
-        return APIClient(user_name="gegnew", password="testpass1")
+        return APIClient(username="gegnew", password="testpass1")
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/resources/test_population.py
+++ b/tests/unit/resources/test_population.py
@@ -27,7 +27,10 @@ def population_tester(population):
     assert hasattr(population, "gates")
     assert hasattr(population, "name")
     assert hasattr(population, "parent_id")
-    assert hasattr(population, "terminal_gate_gid") and len(getattr(population, "terminal_gate_gid")) == 24
+    assert (
+        hasattr(population, "terminal_gate_gid")
+        and len(getattr(population, "terminal_gate_gid")) == 24
+    )
     assert hasattr(population, "unique_name")
 
 

--- a/tests/unit/resources/test_population.py
+++ b/tests/unit/resources/test_population.py
@@ -27,7 +27,7 @@ def population_tester(population):
     assert hasattr(population, "gates")
     assert hasattr(population, "name")
     assert hasattr(population, "parent_id")
-    assert hasattr(population, "terminal_gate_gid")
+    assert hasattr(population, "terminal_gate_gid") and len(getattr(population, "terminal_gate_gid")) == 24
     assert hasattr(population, "unique_name")
 
 

--- a/tests/unit/resources/test_statistics.py
+++ b/tests/unit/resources/test_statistics.py
@@ -102,7 +102,9 @@ def test_should_return_pandas_dataframe(ENDPOINT_BASE, client, statistic_respons
         f"{ENDPOINT_BASE}/experiments/5e4fcb98bdd7ea051d703653/bulkstatistics",
         json=statistic_response,
     )
-    stats = client.get_statistics("5e4fcb98bdd7ea051d703653", "mean", "FSC-A", format="pandas")
+    stats = client.get_statistics(
+        "5e4fcb98bdd7ea051d703653", "mean", "FSC-A", format="pandas"
+    )
     properties = [
         "fcsFileId",
         "filename",

--- a/tests/unit/resources/test_statistics.py
+++ b/tests/unit/resources/test_statistics.py
@@ -102,9 +102,7 @@ def test_should_return_pandas_dataframe(ENDPOINT_BASE, client, statistic_respons
         f"{ENDPOINT_BASE}/experiments/5e4fcb98bdd7ea051d703653/bulkstatistics",
         json=statistic_response,
     )
-    stats = client.get_statistics(
-        "5e4fcb98bdd7ea051d703653", "mean", "FSC-A", format="pandas"
-    )
+    stats = client.get_statistics("5e4fcb98bdd7ea051d703653", "mean", "FSC-A", format="pandas")
     properties = [
         "fcsFileId",
         "filename",

--- a/tests/unit/utils/test_api_client.py
+++ b/tests/unit/utils/test_api_client.py
@@ -225,6 +225,7 @@ def test_should_get_scaleset(client, ENDPOINT_BASE, scalesets):
     assert type(s is ScaleSet)
     assert s._id == SCALESET_ID
 
+
 @responses.activate
 def test_should_get_statistics(client, ENDPOINT_BASE, statistics):
     responses.add(

--- a/tests/unit/utils/test_api_client.py
+++ b/tests/unit/utils/test_api_client.py
@@ -215,6 +215,17 @@ def test_should_get_plot(client, ENDPOINT_BASE):
 
 
 @responses.activate
+def test_should_get_scaleset(client, ENDPOINT_BASE, scalesets):
+    responses.add(
+        responses.GET,
+        f"{ENDPOINT_BASE}/experiments/{EXP_ID}/scalesets",
+        json=[scalesets],
+    )
+    s = client.get_scaleset(EXP_ID)
+    assert type(s is ScaleSet)
+    assert s._id == SCALESET_ID
+
+@responses.activate
 def test_should_get_statistics(client, ENDPOINT_BASE, statistics):
     responses.add(
         responses.POST,
@@ -247,15 +258,3 @@ def test_should_get_statistics(client, ENDPOINT_BASE, statistics):
         population_ids="some population id",
     )
     assert set(expected_query_body) == set(json.loads(responses.calls[0].request.body))
-
-
-@responses.activate
-def test_should_get_scaleset(client, ENDPOINT_BASE, scalesets):
-    responses.add(
-        responses.GET,
-        f"{ENDPOINT_BASE}/experiments/{EXP_ID}/scalesets",
-        json=[scalesets],
-    )
-    s = client.get_scaleset(EXP_ID)
-    assert type(s is ScaleSet)
-    assert s._id == SCALESET_ID

--- a/tests/unit/utils/test_base_api_client.py
+++ b/tests/unit/utils/test_base_api_client.py
@@ -2,7 +2,6 @@ import pytest
 import requests
 import responses
 
-# from cellengine.utils.api_client.APIClient import APIClient
 from cellengine.utils.api_client.APIError import APIError
 
 

--- a/tests/unit/utils/test_complex_population.py
+++ b/tests/unit/utils/test_complex_population.py
@@ -14,24 +14,6 @@ ID6 = "5f1178fc2c50066876d24acf"
 ID7 = "5f1178fc2c50066876d24acg"
 
 
-@responses.activate
-def test_create_complex_population_basic(ENDPOINT_BASE, experiment, gates, populations):
-    with pytest.raises(NotImplementedError):
-        responses.add(
-            responses.POST,
-            f"{ENDPOINT_BASE}/experiments/{EXP_ID}/populations",
-            json=populations[0],
-            status=201,
-        )
-        experiment.create_population(
-            population=ComplexPopulationBuilder("pop_name")
-            .And([ID1, ID2])
-            .Not(ID3)
-            .build()
-        )
-        # TODO: assert correct body upon implementation
-
-
 def test_should_build_query_from_string_or_list():
     expected_output = {
         "name": "pop_name",


### PR DESCRIPTION
Closes:
https://github.com/primitybio/cellengine-python-toolkit/issues/69
https://github.com/primitybio/cellengine-python-toolkit/issues/68
https://github.com/primitybio/cellengine-python-toolkit/issues/65
https://github.com/primitybio/cellengine-python-toolkit/issues/66
https://github.com/primitybio/cellengine-python-toolkit/issues/70

It also fixes all the type warnings from `mkdocstrings`.