### PR TITLE
Bump Pillow to 8.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ pytest-vcr~=1.0
 responses~=0.10
 flake8~=3.7
 black==19.10b0
-Pillow~=7.0
+Pillow~=8.0
 mkdocs~=1.1
 mkdocs-material~=6.1
 mkdocs-material-extensions~=1.0


### PR DESCRIPTION
This version of Pillow breaks Python 3.5 support. This should be fine, since we're supporting 3.6+.
 
For details: https://pillow.readthedocs.io/en/stable/releasenotes/8.0.0.html

Closes https://github.com/primitybio/cellengine-python-toolkit/issues/81