### PR TITLE
feat: introduce dataclasses and dataclasses_json

### DIFF
--- a/cellengine/utils/dataclass_mixin.py
+++ b/cellengine/utils/dataclass_mixin.py
@@ -1,0 +1,13 @@
+from dataclasses_json import DataClassJsonMixin
+import dataclasses_json
+
+
+class DataClassMixin(DataClassJsonMixin):
+    """Mixin to use dataclasses_json for serialization/deserialization of CE entities.
+
+    Extends the DataClassJsonMixin to support camelCase -> snake_case."""
+
+    dataclass_json_config = dataclasses_json.config(  # type: ignore
+        letter_case=dataclasses_json.LetterCase.CAMEL,  # type: ignore
+        undefined=dataclasses_json.Undefined.EXCLUDE,
+    )["dataclasses_json"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest~=5.3
 pytest-vcr~=1.0
+pyright~=0.0.9
 responses~=0.10
 flake8~=3.7
 black==19.10b0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     install_requires=[
         "attrs~=20.2",
         "fcsparser~=0.2",
+        "dataclasses-json~=0.5",
         "munch~=2.5",
         "numpy~=1.17",
         "pandas~=1.1",


### PR DESCRIPTION
Introduce dataclasses and (de)serialization via `dataclasses_json`

Waiting on https://github.com/lidatong/dataclasses-json/pull/312 to be merged, and then the `dependency_links` in setup.py can be removed.
