### PR TITLE
feat: add readonly properties to dataclasses

### DIFF
--- a/cellengine/utils/dataclass_mixin.py
+++ b/cellengine/utils/dataclass_mixin.py
@@ -13,3 +13,31 @@ class DataClassMixin(DataClassJsonMixin):
         # Don't encode None values with to_dict or to_json
         exclude=lambda f: f is None,  # type: ignore
     )["dataclasses_json"]
+
+
+class ReadOnly:
+    def __init__(self, optional=False):
+        self.optional = optional
+        self.block_set = False
+
+    def __set_name__(self, owner, attr):
+        self.owner = owner.__name__
+        self.attr = attr
+
+    def __get__(self, instance, owner):
+        return getattr(instance, f"_{self.attr}")
+
+    def __set__(self, instance, value):
+        if not self.block_set or not hasattr(instance, f"_{self.attr}"):
+            self.block_set = True
+            if type(value) is ReadOnly:
+                if self.optional:
+                    setattr(instance, f"_{self.attr}", None)
+                else:
+                    raise AttributeError(
+                        f"Property '{self.attr}' is required for object '{self.owner}'."
+                    )
+            else:
+                setattr(instance, f"_{self.attr}", value)
+        else:
+            raise AttributeError(f"{self.owner}.{self.attr} cannot be set.")

--- a/tests/unit/utils/test_dataclass_mixin.py
+++ b/tests/unit/utils/test_dataclass_mixin.py
@@ -1,0 +1,51 @@
+import pytest
+from dataclasses import dataclass, field
+import json
+
+from dataclasses_json.cfg import config
+from cellengine.utils.dataclass_mixin import DataClassMixin, ReadOnly
+
+
+@dataclass
+class DC(DataClassMixin):
+    _id: str = field(metadata=config(field_name="_id"))
+    foo: int
+    prop: str = field(default=ReadOnly())  # type: ignore
+    optional_prop: str = field(default=ReadOnly(optional=True))  # type: ignore
+
+
+def test_should_deserialize_from_dict():
+    data = {"_id": "some-id", "foo": 9, "prop": "some prop"}
+    t = DC.from_dict(data)
+    assert t.prop == "some prop"
+
+
+def test_should_deserialize_from_json():
+    data = {"_id": "some-id", "foo": 9, "prop": "some prop"}
+    t = DC.from_json(json.dumps(data))
+    assert t.prop == "some prop"
+
+
+def test_should_serialize_to_dict():
+    data = {"_id": "some-id", "foo": 9, "prop": "some prop"}
+    t = DC.from_dict(data)
+    assert t.to_dict() == data
+
+
+def test_should_serialize_to_json():
+    data = {"_id": "some-id", "foo": 9, "prop": "some prop"}
+    t = DC.from_dict(data)
+    assert t.to_json() == json.dumps(data)
+
+
+def test_should_not_allow_setting_readonly_property():
+    data = {"_id": "some-id", "foo": 9, "prop": "some prop"}
+    t = DC.from_dict(data)
+    with pytest.raises(AttributeError):
+        t.prop = "something else"
+
+
+def test_optional_readonly_property_should_be_none():
+    data = {"_id": "some-id", "foo": 9, "prop": "some prop"}
+    t = DC.from_dict(data)
+    assert t.optional_prop == None


### PR DESCRIPTION
I could use `dataclasses`, `attrs`, _or_ `pydantic` for creating type-safe entities with the right properties. Additionally, there's about 6 serialization/deserialization libraries that could all be used here, including `marshmallow`, `dataclasses_json`, `cattrs`, `json`, etc. 

The crux of the issue here is that `dataclasses` supports only frozen classes, but not frozen _properties_. `attrs` supports both.

This PR suggests a way of maintaining read-only properties for the combination of `dataclasses`/`dataclasses_json`. (The latter uses `marshmallow` under the hood, which is fine, I think :shrug:.) 

The alternative method would be to continue using `attrs`, since it supports read-only properties, and then improve data serialization (and get type safety!) by replacing my `GetSet` class with `cattrs`. It might look something like:
```python
import cattr
from attr import dataclass  # note the dataclass decorator comes from attrs here, not dataclasses

@dataclass
class Compensation:
    _id: str
    spillMatrix: DataFrame

def convert_dataframe(data, _class):
    return _class(
        data=array(data).reshape(
            sum(data), sum(data)
        ),
        # columns=self.channels,
        # index=self.channels,
    )

a = cattr.GenConverter()
a.register_structure_hook(DataFrame, convert_dataframe)  # for instance to serialize a dataframe
# a similar hook would have to be implemented to convert camelCase JSON to snake_case python objects
comp = a.structure(dict_or_json_of_compensation, Compensation)
```
