### PR TITLE
src(dataclasses): allow serialization of read-only dicts

### DIFF
--- a/cellengine/utils/dataclass_mixin.py
+++ b/cellengine/utils/dataclass_mixin.py
@@ -20,6 +20,12 @@ class ReadOnly:
         self.optional = optional
         self.block_set = False
 
+    def keys(self):
+        return []
+
+    def values(self):
+        return []
+
     def __set_name__(self, owner, attr):
         self.owner = owner.__name__
         self.attr = attr


### PR DESCRIPTION
There is an error during type-checking when a dict gets deserialized by `dataclasses_json`, and this fixes that issue.
