### PR TITLE
src(misc): small changes for wrapped_image_opener, tests, type hints

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,7 +46,7 @@ jobs:
           pip install pytest
           pip install pytest-cov
           python -m pytest --cov=./ --cov-report=xml
-      - name: Upload coverage to Codecov  
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/cellengine/payloads/scale_utils/scale_dict.py
+++ b/cellengine/payloads/scale_utils/scale_dict.py
@@ -1,5 +1,0 @@
-from cellengine.utils.limited_dict import LimitedDict
-
-
-class ScaleDict(LimitedDict):
-    _keys = {"type", "minimum", "maximum", "cofactor"}

--- a/cellengine/resources/attachment.py
+++ b/cellengine/resources/attachment.py
@@ -36,7 +36,7 @@ class Attachment(DataClassMixin):
 
     @staticmethod
     def upload(experiment_id: str, filepath: str, filename: str = None) -> Attachment:
-        return ce.APIClient().post_attachment(experiment_id, filepath, filename)
+        return ce.APIClient().upload_attachment(experiment_id, filepath, filename)
 
     def update(self):
         """Save changes to this Attachment to CellEngine.

--- a/cellengine/resources/experiment.py
+++ b/cellengine/resources/experiment.py
@@ -247,7 +247,7 @@ class Experiment(DataClassMixin):
 
     def upload_attachment(self, filepath: str, filename: str = None):
         """Upload an attachment to this experiment."""
-        ce.APIClient().post_attachment(self._id, filepath, filename)
+        ce.APIClient().upload_attachment(self._id, filepath, filename)
 
     @property
     def compensations(self) -> List[Compensation]:

--- a/cellengine/resources/experiment.py
+++ b/cellengine/resources/experiment.py
@@ -27,6 +27,12 @@ from cellengine.resources.gate import (
     EllipseGate,
     QuadrantGate,
 )
+from cellengine.utils.helpers import (
+    CommentList,
+    datetime_to_timestamp,
+    timestamp_to_datetime,
+)
+
 from cellengine.payloads.gate_utils import (
     format_rectangle_gate,
     format_polygon_gate,
@@ -34,11 +40,6 @@ from cellengine.payloads.gate_utils import (
     format_range_gate,
     format_split_gate,
     format_quadrant_gate,
-)
-from cellengine.utils.helpers import (
-    CommentList,
-    datetime_to_timestamp,
-    timestamp_to_datetime,
 )
 
 

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -30,7 +30,7 @@ class FcsFile(DataClassMixin):
     has_file_internal_comp: bool = field(default=ReadOnly())  # type: ignore
     header: Optional[str] = field(default=ReadOnly(optional=True))  # type: ignore
     md5: str = field(default=ReadOnly())  # type: ignore
-    sample_name: str = field(default=ReadOnly())  # type: ignore
+    sample_name: Optional[str] = field(default=ReadOnly(optional=True))  # type: ignore
     size: int = field(default=ReadOnly())  # type: ignore
     _spill_string: Optional[str] = field(
         metadata=config(field_name="spillString"), default=None

--- a/cellengine/resources/scaleset.py
+++ b/cellengine/resources/scaleset.py
@@ -6,8 +6,8 @@ from dataclasses_json.cfg import config
 from pandas import DataFrame
 
 import cellengine as ce
-from cellengine.payloads.scale_utils.apply_scale import apply_scale
-from cellengine.payloads.scale_utils.scale_dict import ScaleDict
+from cellengine.utils.scale_utils import apply_scale
+from cellengine.utils.scale_utils import ScaleDict
 from cellengine.resources.fcs_file import FcsFile
 from cellengine.utils.dataclass_mixin import DataClassMixin, ReadOnly
 

--- a/cellengine/utils/api_client/APIClient.py
+++ b/cellengine/utils/api_client/APIClient.py
@@ -144,7 +144,7 @@ class APIClient(BaseAPIClient, metaclass=Singleton):
         except IndexError:
             raise RuntimeError("No experiment with that name or _id found.")
 
-    def post_attachment(
+    def upload_attachment(
         self, experiment_id, filepath: str, filename: str = None
     ) -> Attachment:
         """Upload an attachment

--- a/cellengine/utils/api_client/APIError.py
+++ b/cellengine/utils/api_client/APIError.py
@@ -3,9 +3,9 @@ import attr
 
 @attr.s(auto_exc=True)
 class APIError(BaseException):
-    url = attr.ib()
-    status_code = attr.ib()
-    message = attr.ib()
+    url: str = attr.ib()
+    status_code: int = attr.ib()
+    message: str = attr.ib()
 
     def __str__(self):
         if self.status_code:

--- a/cellengine/utils/api_client/BaseAPIClient.py
+++ b/cellengine/utils/api_client/BaseAPIClient.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
 from abc import abstractmethod
-from typing import Any, Union, List, Dict
+from typing import Any, Dict, List, Union
 
 import requests
+from requests import Response
 from requests.sessions import HTTPAdapter
-from cellengine.utils.singleton import AbstractSingleton
-from cellengine.utils.api_client.APIError import APIError
+
 from cellengine import __version__ as CEV
+from cellengine.utils.api_client.APIError import APIError
+from cellengine.utils.singleton import AbstractSingleton
 
 
 class BaseAPIClient(metaclass=AbstractSingleton):
@@ -39,7 +42,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
             request_headers.update(headers)
         return request_headers
 
-    def _parse_response(self, response, raw=False):
+    def _parse_response(self, response: Response, raw: bool = False) -> Any:
         success = 200 <= response.status_code < 300
 
         if success and raw:
@@ -73,13 +76,13 @@ class BaseAPIClient(metaclass=AbstractSingleton):
     def _post(
         self,
         url,
-        json: Union[Dict, List[Dict]] = None,
+        json: Union[Dict[Any, Any], List[Dict[Any, Any]]] = None,
         params: Dict = None,
         headers: Dict = None,
         files: Dict = None,
         data=None,
         raw=False,
-    ) -> Dict:
+    ) -> Any:
         response = self.requests_session.post(
             url,
             json=json,
@@ -98,7 +101,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
         headers: Dict = None,
         files: Dict = None,
         raw=False,
-    ) -> Dict:
+    ):
         response = self.requests_session.patch(
             url,
             json=json,
@@ -108,9 +111,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
         )
         return self._parse_response(response, raw=raw)
 
-    def _delete(
-        self, url, params: dict = None, headers: dict = None, raw=False
-    ) -> dict:
+    def _delete(self, url, params: dict = None, headers: dict = None):
         response = self.requests_session.delete(
             url, headers=self._make_headers(headers), params=params if params else {},
         )
@@ -118,11 +119,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
             if response.ok:
                 return response.content
             else:
-                raise APIError(
-                    response.url,
-                    response.status_code,
-                    response.json() or response["error"],
-                )
+                raise APIError(response.url, response.status_code, response.json())
         except APIError:
             raise
         except Exception as error:

--- a/cellengine/utils/generate_id.py
+++ b/cellengine/utils/generate_id.py
@@ -7,13 +7,10 @@ from random import SystemRandom
 
 
 class OID:
-    pass
-
-
-OID._pid = os.getpid()
-OID._max_counter_value = 0xFFFFFF
-OID._inc = SystemRandom().randint(0, OID._max_counter_value)
-OID._random = os.urandom(5)
+    _pid: int = os.getpid()
+    _max_counter_value: int = 0xFFFFFF
+    _inc: int = SystemRandom().randint(0, _max_counter_value)
+    _random: bytes = os.urandom(5)
 
 
 def _random():

--- a/cellengine/utils/helpers.py
+++ b/cellengine/utils/helpers.py
@@ -7,9 +7,13 @@ first_cap_re = re.compile("(.)([A-Z][a-z]+)")
 all_cap_re = re.compile("([a-z0-9])([A-Z])")
 
 
+def is_valid_id(_id: str) -> bool:
+    return bool(ID_REGEX.match(_id))
+
+
 def check_id(_id):
     try:
-        assert bool(ID_REGEX.match(_id)) is True
+        assert is_valid_id(_id)
     except Exception as e:
         ValueError("Object has an invalid ID.", e)
 

--- a/cellengine/utils/scale_utils.py
+++ b/cellengine/utils/scale_utils.py
@@ -1,9 +1,16 @@
 from collections import defaultdict
-from numpy import log10, arcsinh, clip
-from typing import List
+from typing import Dict
+
+from numpy import arcsinh, clip, log10
+
+from cellengine.utils.limited_dict import LimitedDict
 
 
-def apply_scale(scale: List, item, clamp_q=False):
+class ScaleDict(LimitedDict):
+    _keys = {"type", "minimum", "maximum", "cofactor"}
+
+
+def apply_scale(scale: Dict, item, clamp_q=False):
     _type = scale["type"]
 
     def bad_scale_error(_):

--- a/cellengine/utils/scale_utils.py
+++ b/cellengine/utils/scale_utils.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from typing import Dict
-
 from numpy import arcsinh, clip, log10
 
 from cellengine.utils.limited_dict import LimitedDict

--- a/cellengine/utils/wrapped_image_opener.py
+++ b/cellengine/utils/wrapped_image_opener.py
@@ -1,4 +1,3 @@
-import importlib.util
 from io import BytesIO
 
 from cellengine.utils.singleton import AbstractSingleton
@@ -8,27 +7,29 @@ class WrappedImageOpener(metaclass=AbstractSingleton):
     """Display images with an already-installed image library, if possible"""
 
     def __init__(self):
-        imager = self.find_one_of_packages(["PIL.Image", "IPython.display"])
-        if imager:
-            self.imager = imager
-        else:
-            raise ImportError(
-                "Try installing Pillow with `pip install pillow` \
-                or run in a Jupyter Notebook."
-            )
+        self.imager = self.get_imager()
 
     def open(self, data):
         if "PIL" in str(self.imager):
-            image = self.imager.open(BytesIO(data))
+            image = self.imager.open(BytesIO(data))  # type: ignore
         elif "IPython" in str(self.imager):
-            image = self.imager.display(self.imager.Image(data))
+            image = self.imager.display(self.imager.Image(data))  # type: ignore
+        else:
+            raise RuntimeError("Pillow or IPython is not installed.")
         return image
 
-    def find_one_of_packages(self, package_names):
-        """Find an image library or return None"""
-        for package in package_names:
+    def get_imager(self):
+        try:
+            from PIL import Image
+
+            return Image
+        except ModuleNotFoundError:
             try:
-                lib = importlib.util.find_spec(package)
-                return lib.loader.load_module()
-            except Exception:
-                continue
+                from IPython import display
+
+                return display
+            except ModuleNotFoundError:
+                raise ImportError(
+                    "Try installing Pillow with `pip install pillow` \
+                    or run in a Jupyter Notebook."
+                )

--- a/tests/fixtures/api-gates.py
+++ b/tests/fixtures/api-gates.py
@@ -1,32 +1,32 @@
 import pytest
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def rectangle_gate():
     return specific_gate("RectangleGate")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def ellipse_gate():
     return specific_gate("EllipseGate")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def polygon_gate():
     return specific_gate("PolygonGate")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def range_gate():
     return specific_gate("RangeGate")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def quadrant_gate():
     return specific_gate("QuadrantGate")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def split_gate():
     return specific_gate("SplitGate")
 
@@ -34,7 +34,6 @@ def split_gate():
 def specific_gate(gate_type):
     gates = {
         "EllipseGate": {
-            "__v": 0,
             "_id": "5d9401613afd657e233843b3",
             "experimentId": "5d38a6f79fae87499999a74b",
             "fcsFileId": None,
@@ -58,7 +57,6 @@ def specific_gate(gate_type):
             "yChannel": "FSC-H",
         },
         "PolygonGate": {
-            "__v": 0,
             "_id": "5d9365b5117dfb76dd9ed4af",
             "experimentId": "5d38a6f79fae87499999a74b",
             "fcsFileId": None,
@@ -88,7 +86,6 @@ def specific_gate(gate_type):
             "yChannel": "FSC-H",
         },
         "QuadrantGate": {
-            "__v": 0,
             "_id": "5db01cb2c2db443d7b99ad2a",
             "experimentId": "5d38a6f79fae87499999a74b",
             "fcsFileId": None,
@@ -122,7 +119,6 @@ def specific_gate(gate_type):
             "yChannel": "FSC-W",
         },
         "RangeGate": {
-            "__v": 0,
             "_id": "5d960ae0086ef688093cfb9c",
             "experimentId": "5d38a6f79fae87499999a74b",
             "fcsFileId": None,
@@ -141,7 +137,6 @@ def specific_gate(gate_type):
             "yChannel": "FSC-W",
         },
         "RectangleGate": {
-            "__v": 0,
             "_id": "5d8d34994e84a1e661f157a1",
             "experimentId": "5d38a6f79fae87499999a74b",
             "fcsFileId": None,
@@ -160,7 +155,6 @@ def specific_gate(gate_type):
             "yChannel": "FSC-A",
         },
         "SplitGate": {
-            "__v": 0,
             "_id": "5db02affb5cde93d7c922f93",
             "experimentId": "5d38a6f79fae87499999a74b",
             "fcsFileId": None,
@@ -185,7 +179,6 @@ def specific_gate(gate_type):
 def gates():
     gates = [
         {
-            "__v": 0,
             "_id": "5d64abe2ca9df61349ed8e90",
             "experimentId": "5d64abe2ca9df61349ed8e78",
             "fcsFileId": None,
@@ -219,7 +212,6 @@ def gates():
             "yChannel": "FSC-W",
         },
         {
-            "__v": 0,
             "_id": "5d64abe2ca9df61349ed8e91",
             "experimentId": "5d64abe2ca9df61349ed8e78",
             "fcsFileId": None,
@@ -248,7 +240,6 @@ def gates():
             "yChannel": "FSC-W",
         },
         {
-            "__v": 0,
             "_id": "5d64abe2ca9df61349ed8e92",
             "experimentId": "5d64abe2ca9df61349ed8e78",
             "fcsFileId": None,
@@ -272,7 +263,6 @@ def gates():
             "yChannel": "FSC-H",
         },
         {
-            "__v": 0,
             "_id": "5d64abe2ca9df61349ed8e93",
             "experimentId": "5d64abe2ca9df61349ed8e78",
             "fcsFileId": None,

--- a/tests/unit/resources/scales/test_arc_sinh_scale.py
+++ b/tests/unit/resources/scales/test_arc_sinh_scale.py
@@ -3,7 +3,7 @@ from math import isclose
 from numpy import arcsinh
 from pandas import Series
 
-from cellengine.payloads.scale_utils.apply_scale import apply_scale
+from cellengine.utils.scale_utils import apply_scale
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/resources/scales/test_linear_scale.py
+++ b/tests/unit/resources/scales/test_linear_scale.py
@@ -1,7 +1,7 @@
 import pytest
 from pandas import Series
 
-from cellengine.payloads.scale_utils.apply_scale import apply_scale
+from cellengine.utils.scale_utils import apply_scale
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/resources/scales/test_log_scale.py
+++ b/tests/unit/resources/scales/test_log_scale.py
@@ -3,7 +3,7 @@ from math import isclose
 from numpy import log10
 from pandas import Series
 
-from cellengine.payloads.scale_utils.apply_scale import apply_scale
+from cellengine.utils.scale_utils import apply_scale
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/utils/test_generate_id.py
+++ b/tests/unit/utils/test_generate_id.py
@@ -14,7 +14,7 @@ def test_generates_an_id():
 
 def test_generates_unique_ids():
     id_list = []
-    for i in range(0, 1000):
+    for _ in range(0, 1000):
         _id = generate_id()
         assert _id not in id_list
         id_list.append(_id)

--- a/tests/unit/utils/test_lru_cache.py
+++ b/tests/unit/utils/test_lru_cache.py
@@ -37,7 +37,7 @@ def test_lru_cache(ENDPOINT_BASE, client, experiments):
 
 
 @responses.activate
-def test_lru_cache_paths(ENDPOINT_BASE, client, experiments, fcs_files, experiment):
+def test_lru_cache_paths(ENDPOINT_BASE, client, experiments):
     """Test whether the cache returns a url with a name query on the first
     request and then an ID on the second request."""
     client.cache_clear()


### PR DESCRIPTION
- permit black-style line breaks
- add `is_good_id` and `datetime_to_timestamp`
- scope gate test fixtures to function (rebuilds fixtures for each function, so state mutations don't cause failures)
- update image opener (changes due to api updates in image packages)
- move `parse_fcs_file_args` to `utils/`
- move `scale_utils/` to `utils/scale_utils.py`
- fix misc type hinting
- remove unnecessary conftest.py in root dir
- misc minor fixes
- fix ReadOnly properties in FcsFile
- rename `post_attachment` to `upload_attachment`