### PR TITLE
bug(fcsfile, comp): fix RuntimeWarnings on object creation

### DIFF
--- a/cellengine/resources/compensation.py
+++ b/cellengine/resources/compensation.py
@@ -75,11 +75,11 @@ class Compensation(DataClassMixin):
         channels = [arr.pop(0) for _ in range(length)]
 
         properties = {
-            "_id": None,
+            "_id": "",
             "channels": channels,
             "spillMatrix": [float(n) for n in arr],
-            "experimentId": None,
-            "name": None,
+            "experimentId": "",
+            "name": "",
         }
         return Compensation.from_dict(properties)
 

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -18,7 +18,7 @@ class FcsFile(DataClassMixin):
     filename: str
     is_control: str
     panel_name: str
-    deleted: bool
+    deleted: Optional[bool]
     panel: List[Dict[str, Any]]
     _id: str = field(
         metadata=config(field_name="_id"), default=ReadOnly()
@@ -30,7 +30,7 @@ class FcsFile(DataClassMixin):
     has_file_internal_comp: bool = field(default=ReadOnly())  # type: ignore
     header: Optional[str] = field(default=ReadOnly(optional=True))  # type: ignore
     md5: str = field(default=ReadOnly())  # type: ignore
-    sample_name: str = field(default=ReadOnly())  # type: ignore
+    sample_name: Optional[str] = field(default=ReadOnly(optional=True))  # type: ignore
     size: int = field(default=ReadOnly())  # type: ignore
     _spill_string: Optional[str] = field(
         metadata=config(field_name="spillString"), default=None

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -204,6 +204,8 @@ class FcsFile(DataClassMixin):
         To fetch a file with specific parameters (e.g. subsampling, or
         gated to a specific population) see `FcsFile.get_events()`.
         """
+        if not hasattr(self, "_events"):
+            self._events = DataFrame()
         if self._events.empty:
             self.get_events(inplace=True)
             return self._events


### PR DESCRIPTION
This is a hotfix for runtime warnings, but will be made irrelevant by the
`cattrs` branch, I hope.

- bug(fcs_file): sample_name is not required
- bug(compensation): fix runtime warnings in `from_spill_string`
