### PR TITLE
bug(*): fix Boolean query params

### DIFF
--- a/cellengine/utils/api_client/APIClient.py
+++ b/cellengine/utils/api_client/APIClient.py
@@ -97,7 +97,7 @@ class APIClient(BaseAPIClient, metaclass=Singleton):
             raise RuntimeError(str(e).format(name))
 
     def _lookup_by_name(self, path, query, name):
-        params = f'query=eq({query},"{name}")&limit=2'
+        params = {"query": f'eq({query},"{name}")', "limit": 2}
         return self._get(f"{self.base_url}/{path}", params=params)
 
     def _handle_response(self, response):

--- a/cellengine/utils/api_client/BaseAPIClient.py
+++ b/cellengine/utils/api_client/BaseAPIClient.py
@@ -11,6 +11,11 @@ from cellengine.utils.api_client.APIError import APIError
 from cellengine.utils.singleton import AbstractSingleton
 
 
+def prepare_params(params: Dict) -> Dict:
+    """Converts Booleans to lower-case strings. (Requests yields upper-case.)"""
+    return {k: str(v).lower() if type(v) == bool else v for k, v in params.items()}
+
+
 class BaseAPIClient(metaclass=AbstractSingleton):
     @property
     @abstractmethod
@@ -67,7 +72,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
             response = self.requests_session.get(
                 url,
                 headers=self._make_headers(headers),
-                params=params if params else {},
+                params=prepare_params(params if params else {}),
             )
         except Exception as error:
             raise error
@@ -87,7 +92,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
             url,
             json=json,
             headers=self._make_headers(headers),
-            params=params if params else {},
+            params=prepare_params(params if params else {}),
             files=files,
             data=data,
         )
@@ -106,7 +111,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
             url,
             json=json,
             headers=self._make_headers(headers),
-            params=params if params else {},
+            params=prepare_params(params if params else {}),
             files=files,
         )
         return self._parse_response(response, raw=raw)
@@ -115,7 +120,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
         response = self.requests_session.delete(
             url,
             headers=self._make_headers(headers),
-            params=params if params else {},
+            params=prepare_params(params if params else {}),
         )
         try:
             if response.ok:

--- a/tests/unit/resources/test_plots.py
+++ b/tests/unit/resources/test_plots.py
@@ -101,7 +101,11 @@ def test_should_get_plot_for_each_query_parameter(
             item = ("color", "%23ff0000")
 
         assert item[0] in responses.calls[i].request.url
-        assert str(item[1]) in responses.calls[i].request.url
+        assert (
+            str(item[1]).lower()
+            if type(item[1]) is bool
+            else str(item[1]) in responses.calls[i].request.url
+        )
         plot_tester(plot)
         i += 1
 

--- a/tests/unit/utils/test_lru_cache.py
+++ b/tests/unit/utils/test_lru_cache.py
@@ -52,7 +52,8 @@ def test_lru_cache_paths(ENDPOINT_BASE, client, experiments):
     client.get_experiment(name="test_experiment")
     assert (
         responses.calls[0].request.url
-        == ENDPOINT_BASE + "/experiments?query=eq(name,%22test_experiment%22)&limit=2"
+        == ENDPOINT_BASE
+        + "/experiments?query=eq%28name%2C%22test_experiment%22%29&limit=2"
     )
 
     responses.add(responses.GET, ENDPOINT_BASE + "/experiments", json=experiments[0])


### PR DESCRIPTION
Affects plots and anything else where CellEngine's API is case-sensitive (might only be plots). We'll make the API case-insensitive at some point soon as well.

Fixes #124