### PR TITLE
bug(scaleset): Only a subset of columns returned by ScaleSet.apply

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E226,E302,E41,W503
+ignore = E226,E302,E41,W503,E704
 max-line-length = 88
 exclude = tests/*


### PR DESCRIPTION
`ScaleSet.apply` was returning a subset of the original event data, not all the data with a scale applied.

For instance, when:
- the `ScaleSet.scales` contained `["Scale1", "Scale2"]
- the `FcsFile.events` contained `["Scale2", "Scale3"]`

Then:
- `ScaleSet.apply()` would return a dataframe with columns `["Scale2"]`

Instead, now it will return a dataframe with columns `["Scale2", "Scale3"]`

This also fixes a typing error with `@overload`

Fixes #126 