### PR TITLE
feat: Add support for transfers from S3 to FcsFile.create

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,6 +46,9 @@ jobs:
           pip install pytest
           pip install pytest-cov
           python -m pytest --cov=./ --cov-report=xml
+        env:
+          S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY}}
+          S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY}}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/cellengine/resources/fcs_file.py
+++ b/cellengine/resources/fcs_file.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from cellengine.utils.helpers import is_valid_id
 from cellengine.utils.parse_fcs_file import parse_fcs_file
 from cellengine.utils.dataclass_mixin import DataClassMixin, ReadOnly
 from dataclasses import dataclass, field
@@ -102,7 +103,7 @@ class FcsFile(DataClassMixin):
     def create(
         cls,
         experiment_id: str,
-        fcs_files: List[str],
+        fcs_files: Union[str, List[str], Dict[str, str]],
         filename: str = None,
         add_file_number: bool = False,
         add_event_number: bool = False,
@@ -110,17 +111,57 @@ class FcsFile(DataClassMixin):
         pre_subsample_p: float = None,
         seed: int = None,
     ) -> FcsFile:
-        """Creates an FCS file by copying, concatenating and/or subsampling
-        existing file(s) from this or other experiments.
+        """Creates an FCS file by copying, concatenating and/or
+        subsampling existing file(s) from this or other experiments, or by
+        importing from an S3-compatible service. This endpoint can be used to
+        import files from other experiments.
 
-        This endpoint can be used to import files from other experiments.
+        When concatenating and subsampling at the same time, subsampling is
+        applied to each file before concatenating.
+
+        If addFileNumber is true, a file number column (channel) will be added to the
+        output file indicating which file each event (cell) came from. The values in
+        this column have a uniform random spread (±0.25 of the integer value) to ease
+        visualization. While this column can be useful for analysis, it will cause the
+        experiment to have FCS files with different panels unless all FCS files that
+        have not been concatenated are deleted.
+
+        During concatenation, any FCS header parameters that do not match
+        between files will be removed, with some exceptions:
+
+            - $BTIM (clock time at beginning of acquisition) and $DATE will be
+            set to the earliest value among the input files.
+            - $ETIM (clock time at end of acquisition) will be set to the latest value
+            among the input files.
+            - $PnR (range for parameter n) will be set to
+            the highest value among the input files.
+
+        All channels present in the first FCS file in the fcsFiles parameter
+        must also be present in the other FCS files.
+
+        When importing from an S3-compatible service, be aware of the
+        following:
+
+            - Only a single file can be imported at a time.
+            - The host property must include the bucket and region as
+              applicable. For example, for AWS, this would look like
+              mybucket.s3.us-east-2.amazonaws.com.
+            - The path property must specify the full path to the object, e.g.
+              /Study001/Specimen01.fcs.
+            - Importing private S3 objects requires an accessKey and a
+              secretKey for a user with appropriate permissions. For AWS,
+              GetObject is required.
+            - Importing objects may incur fees from the S3 service provider.
 
         Args:
             experiment_id: ID of the experiment to which the file belongs
             fcs_files: ID of file or list of IDs of files or objects to process.
                 If more than one file is provided, they will be concatenated in
                 order. To import files from other experiments, pass a list of dicts
-                with _id and experimentId properties.
+                with _id and experimentId properties. To import a file from an
+                S3-compatible service, provide a Dict with keys "host" and
+                "path"; if the S3 object is private, additionally provide
+                "access_key" and "secret_key".
             filename (optional): Rename the uploaded file.
             add_file_number (optional): If
                 concatenating files, adds a file number channel to the
@@ -142,10 +183,17 @@ class FcsFile(DataClassMixin):
         """
 
         def _parse_fcs_file_args(args):
-            if type(args) is list:
+            if type(args) is list and all(is_valid_id(arg) for arg in args):
                 return args
-            else:
+            elif type(args) is dict:
+                if {"host", "path"} <= args.keys():
+                    return [args]
+                if {"_id", "experiment_id"} <= args.keys():
+                    return [args]
+            elif type(args) is str and is_valid_id(args):
                 return [args]
+            else:
+                raise ValueError("Invalid parameters for 'fcs_file'.")
 
         body = {"fcsFiles": _parse_fcs_file_args(fcs_files), "filename": filename}
         optional_params = {
@@ -179,7 +227,7 @@ class FcsFile(DataClassMixin):
         population_id: str = None,
         **kwargs,
     ) -> Plot:
-        """Buid a plot for an FcsFile.
+        """Build a plot for an FcsFile.
 
         See [`Plot.get`][cellengine.resources.plot.Plot.get] for more information.
         """

--- a/cellengine/utils/api_client/BaseAPIClient.py
+++ b/cellengine/utils/api_client/BaseAPIClient.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import abstractmethod
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 from requests import Response
@@ -8,6 +8,7 @@ from requests.sessions import HTTPAdapter
 
 from cellengine import __version__ as CEV
 from cellengine.utils.api_client.APIError import APIError
+from cellengine.utils.helpers import alter_keys, to_camel_case
 from cellengine.utils.singleton import AbstractSingleton
 
 
@@ -81,16 +82,16 @@ class BaseAPIClient(metaclass=AbstractSingleton):
     def _post(
         self,
         url,
-        json: Union[Dict[Any, Any], List[Dict[Any, Any]]] = None,
-        params: Dict = None,
-        headers: Dict = None,
-        files: Dict = None,
+        json: Optional[Union[Dict, List[Dict]]] = None,
+        params: Optional[Dict] = None,
+        headers: Optional[Dict] = None,
+        files: Optional[Dict] = None,
         data=None,
         raw=False,
     ) -> Any:
         response = self.requests_session.post(
             url,
-            json=json,
+            json=alter_keys(json, to_camel_case) if json else None,
             headers=self._make_headers(headers),
             params=prepare_params(params if params else {}),
             files=files,
@@ -109,7 +110,7 @@ class BaseAPIClient(metaclass=AbstractSingleton):
     ):
         response = self.requests_session.patch(
             url,
-            json=json,
+            json=alter_keys(json, to_camel_case) if json else None,
             headers=self._make_headers(headers),
             params=prepare_params(params if params else {}),
             files=files,

--- a/cellengine/utils/helpers.py
+++ b/cellengine/utils/helpers.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime
+from typing import Any, Dict, List, Union
 
 
 ID_REGEX = re.compile(r"^[a-f0-9]{24}$", re.I)
@@ -23,6 +24,24 @@ def to_camel_case(snake_str: str) -> str:
         return snake_str
     components = snake_str.split("_")
     return components[0] + "".join(x.title() for x in components[1:])
+
+
+def alter_keys(payload: Union[Dict[Any, Any], List[Dict[Any, Any]]], func):
+    """Apply `func` to alter the keys of a dict or list of dicts."""
+    empty = {}
+    if isinstance(payload, list):
+        return [alter_keys(p, func) for p in payload]
+    elif type(payload) is dict:
+        for k, v in payload.items():
+            if isinstance(v, dict):
+                empty[func(k)] = alter_keys(v, func)
+            elif isinstance(v, list):
+                empty[func(k)] = [alter_keys(p, func) for p in v]
+            else:
+                empty[func(k)] = v
+        return empty
+    else:
+        return payload
 
 
 def get_args_as_kwargs(cls_context, locals):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import pandas
 
@@ -18,7 +19,9 @@ from cellengine.utils.complex_population_builder import ComplexPopulationBuilder
 
 @pytest.fixture(scope="module")
 def client():
-    return cellengine.APIClient("gegnew", "testpass123")
+    username = os.environ.get("CELLENGINE_USERNAME", "gegnew")
+    password = os.environ.get("CELLENGINE_PASSWORD", "testpass1")
+    return cellengine.APIClient(username=username, password=password)
 
 
 @pytest.fixture(scope="module")
@@ -255,3 +258,20 @@ def test_experiment_populations(setup_experiment, client):
     # DELETE
     complex_pop.delete()
     assert "complex pop" not in [p.name for p in experiment.populations]
+
+
+def test_create_new_fcsfile_from_s3(setup_experiment, client):
+    experiment = client.get_experiment(name="new_experiment")
+    s3_dict = {
+        "host": "ce-test-s3-a.s3.us-east-2.amazonaws.com",
+        "path": "/Specimen_001_A6_A06.fcs",
+        "access_key": os.environ.get("S3_ACCESS_KEY"),
+        "secret_key": os.environ.get("S3_SECRET_KEY"),
+    }
+
+    file = FcsFile.create(
+        experiment._id,
+        s3_dict,
+        "new name",
+    )
+    assert file.size == 22625

--- a/tests/unit/resources/test_fcs_file_parse_args.py
+++ b/tests/unit/resources/test_fcs_file_parse_args.py
@@ -38,14 +38,37 @@ def test_should_create_fcs_file(ENDPOINT_BASE, client, fcs_files):
 
 
 params = [
+    # (request, expected response)
     (FCSFILE_ID, [FCSFILE_ID]),
     ([FCSFILE_ID], [FCSFILE_ID]),
     (
-        ["fcs_file_id_1", "fcs_file_id_2", "fcs_file_id_3"],
-        ["fcs_file_id_1", "fcs_file_id_2", "fcs_file_id_3"],
+        [
+            "5d64abe2ca9df61349ed8e7a",
+            "5d64abe2ca9df61349ed8e7b",
+            "5d64abe2ca9df61349ed8e7c",
+        ],
+        [
+            "5d64abe2ca9df61349ed8e7a",
+            "5d64abe2ca9df61349ed8e7b",
+            "5d64abe2ca9df61349ed8e7c",
+        ],
     ),
-    ({EXP_ID: FCSFILE_ID}, [{EXP_ID: FCSFILE_ID}]),
-    ([{EXP_ID: FCSFILE_ID}], [{EXP_ID: FCSFILE_ID}]),
+    (
+        {"experiment_id": EXP_ID, "_id": FCSFILE_ID},
+        [{"experimentId": EXP_ID, "_id": FCSFILE_ID}],
+    ),
+    (
+        {
+            "host": "ce-test-s3-a.s3.us-east-2.amazonaws.com",
+            "path": "/Specimen_001_A6_A06.fcs",
+        },
+        [
+            {
+                "host": "ce-test-s3-a.s3.us-east-2.amazonaws.com",
+                "path": "/Specimen_001_A6_A06.fcs",
+            }
+        ],
+    ),
 ]
 
 

--- a/tests/unit/utils/test_base_api_client.py
+++ b/tests/unit/utils/test_base_api_client.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 import requests
 import responses
 
@@ -50,10 +51,26 @@ def test_should_post(client):
 
 
 @responses.activate
+def test_should_post_params_as_camel_case(client):
+    body = {"some_param": "body"}
+    responses.add(responses.POST, BASE_URL + "test", json=body)
+    client._post("http://fake/test", body)
+    assert json.loads(responses.calls[0].request.body) == {"someParam": "body"}  # type: ignore
+
+
+@responses.activate
 def test_should_patch(client):
     body = {"some": "body"}
     responses.add(responses.PATCH, BASE_URL + "test", json=body)
     assert client._patch("http://fake/test", body) == {"some": "body"}
+
+
+@responses.activate
+def test_should_patch_params_as_camel_case(client):
+    body = {"some_param": "body"}
+    responses.add(responses.PATCH, BASE_URL + "test", json=body)
+    client._patch("http://fake/test", body)
+    assert json.loads(responses.calls[0].request.body) == {"someParam": "body"}  # type: ignore
 
 
 @responses.activate

--- a/tests/unit/utils/test_helpers.py
+++ b/tests/unit/utils/test_helpers.py
@@ -9,7 +9,7 @@ def test_alter_keys_converts_dict_to_camel_case():
         "fcsFile": "baz",
     }
     r = alter_keys(d, to_camel_case)
-    assert {"_id", "experimentId", "fcsFile"} <= r.keys()
+    assert {"_id", "experimentId", "fcsFile"} == r.keys()
 
 
 def test_alter_keys_converts_nested_dict_to_camel_case():
@@ -23,8 +23,8 @@ def test_alter_keys_converts_nested_dict_to_camel_case():
         },
     }
     r = alter_keys(d, to_camel_case)
-    assert {"_id", "experimentId", "fcsFile"} <= r.keys()
-    assert {"_id", "experimentId", "fcsFile"} <= r["fcsFile"].keys()
+    assert {"_id", "experimentId", "fcsFile"} == r.keys()
+    assert {"_id", "experimentId", "fcsFile"} == r["fcsFile"].keys()
 
 
 def test_alter_keys_converts_list_of_dicts_to_camel_case():
@@ -41,7 +41,7 @@ def test_alter_keys_converts_list_of_dicts_to_camel_case():
         },
     ]
     r = alter_keys(d, to_camel_case)
-    assert {"_id", "experimentId", "fcsFile"} <= r[0].keys()
+    assert {"_id", "experimentId", "fcsFile"} == r[0].keys()
 
 
 params = [

--- a/tests/unit/utils/test_helpers.py
+++ b/tests/unit/utils/test_helpers.py
@@ -1,0 +1,106 @@
+import pytest
+from cellengine.utils.helpers import alter_keys, to_camel_case
+
+
+def test_alter_keys_converts_dict_to_camel_case():
+    d = {
+        "_id": "foo",
+        "experiment_id": "bar",
+        "fcsFile": "baz",
+    }
+    r = alter_keys(d, to_camel_case)
+    assert {"_id", "experimentId", "fcsFile"} <= r.keys()
+
+
+def test_alter_keys_converts_nested_dict_to_camel_case():
+    d = {
+        "_id": "foo",
+        "experiment_id": "bar",
+        "fcsFile": {
+            "_id": "foo",
+            "experiment_id": "bar",
+            "fcsFile": "baz",
+        },
+    }
+    r = alter_keys(d, to_camel_case)
+    assert {"_id", "experimentId", "fcsFile"} <= r.keys()
+    assert {"_id", "experimentId", "fcsFile"} <= r["fcsFile"].keys()
+
+
+def test_alter_keys_converts_list_of_dicts_to_camel_case():
+    d = [
+        {
+            "_id": "foo",
+            "experiment_id": "bar",
+            "fcsFile": "baz",
+        },
+        {
+            "_id": "foo",
+            "experiment_id": "bar",
+            "fcsFile": "baz",
+        },
+    ]
+    r = alter_keys(d, to_camel_case)
+    assert {"_id", "experimentId", "fcsFile"} <= r[0].keys()
+
+
+params = [
+    "hello",
+    1001,
+    1.0,
+    1j,
+    [1, 2],
+    ("a", "b"),
+    range(4),
+    True,
+    b"foo",
+    None,
+]
+
+
+@pytest.mark.parametrize("payload", params)
+def test_alter_keys_returns_passed_payload_if_not_dict_or_list(payload):
+    r = alter_keys(payload, to_camel_case)
+    assert r == payload
+
+
+def test_alter_keys_doesnt_mutate_or_drop_values():
+    d = {
+        "str": "str",
+        "int": 20890,
+        "float": 1.99,
+        "complex": 1j,
+        "list": [],
+        "tuple": (),
+        "range": range(2),
+        "dict": {"a": 1},
+        "set": {"a", "b"},
+        "bool": True,
+        "bytes": b"foo",
+        "bytearray": bytearray(4),
+        "None": None,
+    }
+    r = alter_keys(d, to_camel_case)
+    assert r == d
+
+
+def test_alter_keys_works_with_lists_inside_dicts():
+    d = {
+        "fcs_files": [
+            {
+                "access_key": "SOMEACCESSKEY",
+                "secret_key": "somesecretkey",
+            }
+        ],
+        "file_name": "my file",
+    }
+    r = alter_keys(d, to_camel_case)
+    assert r == {
+        "fcsFiles": [
+            {
+                "accessKey": "SOMEACCESSKEY",
+                "secretKey": "somesecretkey",
+            }
+        ],
+        "fileName": "my file",
+    }


### PR DESCRIPTION
Conforms to the [API Docs](https://docs.cellengine.com/api/#create_2)
We also get automatic conversion of payloads from snake_case to camelCase in BaseAPIClient, which should allow for some future code removal (or at least build confidenced that we'll always send properly-cased request bodies).

- feat: Add alter_keys fn to recursively modify dict keys
- src: Convert all POST/PATCH payloads to camelCase in BaseAPIClient
- feat: Add support for transfers from S3 to FcsFile.create

Fixes #114 