### PR TITLE
bug(experiment): Comp types not handled correctly

### DIFF
--- a/cellengine/__init__.py
+++ b/cellengine/__init__.py
@@ -1,21 +1,41 @@
 # flake8: noqa
 __version__ = "0.1.0"
 
-from cellengine.utils.api_client.APIClient import APIClient
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 from cellengine.resources.attachment import Attachment
 from cellengine.resources.compensation import Compensation
 from cellengine.resources.experiment import Experiment
 from cellengine.resources.fcs_file import FcsFile
 from cellengine.resources.gate import (
-    Gate,
-    RectangleGate,
-    PolygonGate,
     EllipseGate,
-    SplitGate,
+    Gate,
+    PolygonGate,
     QuadrantGate,
     RangeGate,
+    RectangleGate,
+    SplitGate,
 )
 from cellengine.resources.plot import Plot
 from cellengine.resources.population import Population
 from cellengine.resources.scaleset import ScaleSet
+from cellengine.utils.api_client.APIClient import APIClient
 from cellengine.utils.complex_population_builder import ComplexPopulationBuilder
+
+UNCOMPENSATED: int = 0
+"""Apply no compensation."""
+
+FILE_INTERNAL: int = -1
+"""
+Use the file's internal compensation matrix, if available. If not available, an
+error will be returned from API requests.
+"""
+
+PER_FILE: int = -2
+"""
+Use the compensation assigned to each individual FCS file. Not a valid value for
+`FcsFile.compensation`.
+"""

--- a/docs/compensations.md
+++ b/docs/compensations.md
@@ -15,6 +15,14 @@ CellEngine object. Properties are the snake_case equivalent of those documented
 on the [CellEngine API](https://docs.cellengine.com/api/#compensations) unless
 otherwise noted.
 
+## Special Constants
+
+::: cellengine.UNCOMPENSATED
+
+::: cellengine.FILE_INTERNAL
+
+::: cellengine.PER_FILE
+
 ## Methods
 
 ::: cellengine.resources.compensation.Compensation


### PR DESCRIPTION
The getter and setter methods for Experiment.active_compensation do not
handle special compensation types correctly. This fixes the bug and adds
tests.

See https://github.com/primitybio/cellengine-python-toolkit/issues/146
