### PR TITLE
docs(expt): add docstring to Experiment class

### DIFF
--- a/cellengine/resources/experiment.py
+++ b/cellengine/resources/experiment.py
@@ -45,6 +45,9 @@ from cellengine.payloads.gate_utils import (
 
 @dataclass
 class Experiment(DataClassMixin):
+    """The main container for an analysis. Don't construct directly; use
+    [`Experiment.create`][cellengine.Experiment.create] or
+    [`Experiment.get`][cellengine.Experiment.get]."""
 
     name: str
     annotation_validators: Dict[Any, Any]


### PR DESCRIPTION
Otherwise this renders as a mess: https://primitybio.github.io/cellengine-python-toolkit/experiments/#cellengine.resources.experiment.Experiment