### PR TITLE
deps(mkdocstrings): Bump mkdocstrings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ Pillow~=9.0
 mkdocs~=1.1
 mkdocs-material~=7.3
 mkdocs-material-extensions~=1.0
-mkdocstrings~=0.13
+mkdocstrings[python]~=0.18


### PR DESCRIPTION
`mkdocstrings` has updated their Python parsing backend:
https://mkdocstrings.github.io/handlers/overview/#about-the-python-handlers

It seems to work fine for us, so I've updated, as they're about to
deprecate the old backend.
